### PR TITLE
possible fix for the ULongArray issue and for mode_t portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ cmake_minimum_required(VERSION 3.21)
 project(hacl)
 include("cmake/OptimizeForArchitecture.cmake")
 
-OptimizeForArchitecture()
+# This doesn't work at all on M1 Macs
+# OptimizeForArchitecture()
 
 ADD_LIBRARY(hacl STATIC
     libhacl/src/Hacl_Bignum.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,17 @@ cmake_minimum_required(VERSION 3.21)
 # set(CMAKE_C_COMPILER "/usr/local/bin/gcc-11" CACHE STRING "gcc compiler" FORCE)
 
 project(hacl)
-include("cmake/OptimizeForArchitecture.cmake")
 
 # This doesn't work at all on M1 Macs
+# include("cmake/OptimizeForArchitecture.cmake")
 # OptimizeForArchitecture()
+
+# This line requests that we compile universal binaries.
+# More details:
+#   https://stackoverflow.com/a/65811061
+#   https://stackoverflow.com/questions/67490441/cmake-universal-binary-arch-depending-compile-options
+# CMAKE_OSX_ARCHITECTURES=arm64;x86_64
+set (CMAKE_OSX_ARCHITECTURES arm64 x86_64)
 
 ADD_LIBRARY(hacl STATIC
     libhacl/src/Hacl_Bignum.c

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,8 +95,8 @@ kotlin {
         val commonMain by
             getting {
                 dependencies {
-                    implementation(kotlin("stdlib-common", "$kotlinVersion"))
-                    implementation(kotlin("stdlib", "$kotlinVersion"))
+                    implementation(kotlin("stdlib-common", kotlinVersion))
+                    implementation(kotlin("stdlib", kotlinVersion))
 
                     // JSON serialization and DSL
                     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
@@ -128,8 +128,8 @@ kotlin {
         val commonTest by
             getting {
                 dependencies {
-                    implementation(kotlin("test-common", "$kotlinVersion"))
-                    implementation(kotlin("test-annotations-common", "$kotlinVersion"))
+                    implementation(kotlin("test-common", kotlinVersion))
+                    implementation(kotlin("test-annotations-common", kotlinVersion))
 
                     // runTest() for running suspend functions in tests
                     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
@@ -141,7 +141,7 @@ kotlin {
         val jvmMain by
             getting {
                 dependencies {
-                    implementation(kotlin("stdlib-jdk8", "$kotlinVersion"))
+                    implementation(kotlin("stdlib-jdk8", kotlinVersion))
 
                     // Progress bars
                     implementation("me.tongfei:progressbar:0.9.3")
@@ -157,7 +157,7 @@ kotlin {
                 dependencies {
                     // Unclear if we really need all the extra features of JUnit5, but it would
                     // at least be handy if we could get its parallel test runner to work.
-                    implementation(kotlin("test-junit5", "$kotlinVersion"))
+                    implementation(kotlin("test-junit5", kotlinVersion))
                 }
             }
         val nativeMain by getting { dependencies {} }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,10 +6,10 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.7.10"
+    kotlin("multiplatform") version "1.7.20-Beta"
 
     // cross-platform serialization support
-    kotlin("plugin.serialization") version "1.7.10"
+    kotlin("plugin.serialization") version "1.7.20-Beta"
 
     // https://github.com/hovinen/kotlin-auto-formatter
     // Creates a `formatKotlin` Gradle action that seems to be reliable.
@@ -24,7 +24,7 @@ plugins {
 group = "electionguard-kotlin-multiplatform"
 version = "1.0-SNAPSHOT"
 
-val kotlinVersion by extra("1.7.10")
+val kotlinVersion by extra("1.7.20-Beta")
 val pbandkVersion by extra("0.14.1")
 
 repositories {
@@ -226,7 +226,7 @@ configurations.forEach {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>()
-    .configureEach { kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn" }
+    .configureEach { kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn" }
 
 publishing {
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 kotlin.mpp.stability.nowarn=true
 kotlin.native.binary.memoryModel=experimental
+org.gradle.jvmargs=-Xmx6g
+kotlin.native.cacheKind.macosArm64=none


### PR DESCRIPTION
This won't compile on my computer, possibly due to some kind of version mismatch issue:
```
> Task :linkDebugTestNative FAILED
e: Compilation failed: The /Library/Developer/CommandLineTools/usr/bin/clang++ command returned non-zero exit code: 1.
output:
error: Invalid record
1 error generated.

 * Source files: 
 * Compiler version info: Konan: 1.7.10 / Kotlin: 1.7.20
 * Output kind: STATIC_CACHE

e: org.jetbrains.kotlin.konan.KonanExternalToolFailure: The /Library/Developer/CommandLineTools/usr/bin/clang++ command returned non-zero exit code: 1.
output:
error: Invalid record
```

But there's at least a chance this might work for you. Please check it out. Of note, I think I've got a portable solution to the `mode_t` issue, and I moved everything from `ULongArray` to `LongArray` and the compiler at least seems to be happy with that. It shouldn't make a difference (fingers crossed) because all of the real compute on those happens inside HACL, which doesn't care.

That said, all the `useNative` stuff now quietly converts `LongArray` to `CPointer<ULongVar>`. This feels bad somehow, even though it keeps the code as clean as possible.

Note: to get this to work at all on my M1 Mac, I had to comment out the `OptimizeForArchitecture.cmake` file. (Related issue: #66). That's probably going to slow things down significantly if we don't find an alternative.
