### PR TITLE
ContestData part 1: renaming and adjusting class and proto fields

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,7 +180,7 @@ val compileProtobuf =
                 "protoc --pbandk_out=./src/commonMain/kotlin/ --proto_path=./src/commonMain/proto " +
                     "common.proto encrypted_ballot.proto encrypted_tally.proto " +
                     "election_record.proto manifest.proto " +
-                    "plaintext_ballot.proto plaintext_tally.proto " +
+                    "plaintext_ballot.proto decrypted_tally.proto " +
                     "trustees.proto"
             project.exec { commandLine = commandLineStr.split(" ") }
         }

--- a/docs/CommandLineInterface.md
+++ b/docs/CommandLineInterface.md
@@ -38,11 +38,11 @@ last update 8/18/2022
 
 6. **Decryption**. The following examples may be useful:
     1. _electionguard.decrypt.RunTrustedTallyDecryption_ is a CLI for testing, that will run locally in a single process, 
-       that reads an EncryptedTally record and local DecryptingTrustee records, decrypts the tally and writes out 
-       a _PlaintextTally_ protobuf record.
+       that reads an EncryptedTally record and local 
+       DecryptingTrustee records, decrypts the tally and writes out a _DecryptedTallyOrBallot_ protobuf record.
     2. _electionguard.decrypt.RunTrustedBallotDecryption_ is a CLI for testing, that will run locally in a single process,
       that reads a spoiled ballot record and local DecryptingTrustee records, decrypts the ballot and writes out a 
-      _PlaintextTally_ protobuf record that represents the decrypted spoiled ballot.
+      _DecryptedTallyOrBallot_ protobuf record that represents the decrypted spoiled ballot.
     3. In the [electionguard-remote](https://github.com/JohnLCaron/electionguard-remote) repo,
        _electionguard.workflow.RunRemoteDecryptionTest_ is a CLI for testing, that will decrypt the EncryptedTally 
        (and optionally spoiled ballots)

--- a/docs/ElectionRecord.md
+++ b/docs/ElectionRecord.md
@@ -17,14 +17,14 @@ topdir/
 One or more of the above files may be present, depending on the output stage.
 
 
-| Name                          | Type                | Workflow stage      |
-|-------------------------------|---------------------|---------------------|
-| electionConfig.protobuf       | ElectionConfig      | start               |
-| electionInitialized.protobuf  | ElectionInitialized | key ceremony output |
-| encryptedBallots.protobuf     | EncryptedBallot*    | encryption output   |
-| tallyResult.protobuf          | TallyResult         | tally output        |
-| decryptionResult.protobuf     | DecryptionResult    | decryption output   |
-| spoiledBallotTallies.protobuf | PlaintextTally*     | decryption output   |
+| Name                          | Type                    | Workflow stage      |
+|-------------------------------|-------------------------|---------------------|
+| electionConfig.protobuf       | ElectionConfig          | start               |
+| electionInitialized.protobuf  | ElectionInitialized     | key ceremony output |
+| encryptedBallots.protobuf     | EncryptedBallot*        | encryption output   |
+| tallyResult.protobuf          | TallyResult             | tally output        |
+| decryptionResult.protobuf     | DecryptionResult        | decryption output   |
+| spoiledBallotTallies.protobuf | DecryptedTallyOrBallot* | decryption output   |
 
 (*) The files encryptedBallots.protobuf and spoiledBallotTallies.protobuf contain multiple length-delimited proto messages. 
 This allows to read messages one at a time, rather than all into memory at once.

--- a/docs/TallyValidation.md
+++ b/docs/TallyValidation.md
@@ -31,25 +31,25 @@ Plaintext Tally Validation may be run as part of verification.
 
 ### A. Referential integrity with Manifest
 
-1. For each PlaintextTally.Contest in the tally, the contestId must match a ContestDescription.contestId in Manifest.contests.
+1. For each DecryptedTallyOrBallot.Contest in the tally, the contestId must match a ContestDescription.contestId in Manifest.contests.
    
-2. Within the PlaintextTally.Contest and matching ContestDescription, each PlaintextTally.Selection.selectionId must match a SelectionDescription.selectionId.
+2. Within the DecryptedTallyOrBallot.Contest and matching ContestDescription, each DecryptedTallyOrBallot.Selection.selectionId must match a SelectionDescription.selectionId.
 
 ### B. Referential integrity with Ciphertext Tally
 
-1. For each PlaintextTally.Contest in the tally, the contestId must match a EncryptedTally.Contest.contestId.
+1. For each DecryptedTallyOrBallot.Contest in the tally, the contestId must match a EncryptedTally.Contest.contestId.
    
-2. Within the PlaintextTally.Contest and matching EncryptedTally.Contest, each PlaintextTally.Selection.selectionId must match a EncryptedTally.Selection.selectionId.
+2. Within the DecryptedTallyOrBallot.Contest and matching EncryptedTally.Contest, each DecryptedTallyOrBallot.Selection.selectionId must match a EncryptedTally.Selection.selectionId.
 
-   2.1 The PlaintextTally.Selection.message must compare equal to the EncryptedTally.Selection.message.
+   2.1 The DecryptedTallyOrBallot.Selection.message must compare equal to the EncryptedTally.Selection.message.
    
 ### C. Duplication
 
-1. All PlaintextTally.Contest must have a unique contestId. 
+1. All DecryptedTallyOrBallot.Contest must have a unique contestId. 
 
    1.1 In the contests map, the key must match the value.object_id.  (JSON only)
 
-2. Within a PlaintextTally.Contest, all PlaintextTally.Selection have a unique selectionId. 
+2. Within a DecryptedTallyOrBallot.Contest, all DecryptedTallyOrBallot.Selection have a unique selectionId. 
 
     2.1 In the selections map, the key must match the value.object_id. (JSON only)
 
@@ -57,9 +57,9 @@ Plaintext Tally Validation may be run as part of verification.
 
 1. All Selection shares have a selectionId matching the Selection.selectionId.
 
-2. Within a PlaintextTally.Selection, the PartialDecryption's have a unique guardianId. 
+2. Within a DecryptedTallyOrBallot.Selection, the PartialDecryption's have a unique guardianId. 
 
-3. There are _nguardians_ PartialDecryptions in the PlaintextTally.Selection.
+3. There are _nguardians_ PartialDecryptions in the DecryptedTallyOrBallot.Selection.
 
 ### E. RecoveredPartialDecryption (when PartialDecryption contains non-empty RecoveredPartialDecryptions)
 

--- a/src/commonMain/kotlin/electionguard/ballot/ContestData.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/ContestData.kt
@@ -1,0 +1,46 @@
+package electionguard.ballot
+
+import electionguard.core.safeEnumValueOf
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger("ContestData")
+
+enum class ContestDataStatus {
+    normal, null_vote, under_vote
+}
+
+data class ContestData(
+    val overvotes: List<Int>,
+    val writeIns: List<String>,
+    val status: ContestDataStatus? = ContestDataStatus.normal,
+) {
+
+    fun publish(): electionguard.protogen.ContestData {
+        return electionguard.protogen
+            .ContestData(
+                this.status?.publishContestDataState() ?: electionguard.protogen.ContestData.Status.NORMAL,
+                this.overvotes,
+                this.writeIns,
+            )
+    }
+}
+
+fun electionguard.protogen.ContestData.import(): ContestData {
+    return ContestData(
+        this.overVotes,
+        this.writeIns,
+        this.vote.importContestDataState(),
+    )
+}
+
+private fun ContestDataStatus.publishContestDataState(): electionguard.protogen.ContestData.Status {
+    return electionguard.protogen.ContestData.Status.fromName(this.name)
+}
+
+private fun electionguard.protogen.ContestData.Status.importContestDataState(): ContestDataStatus? {
+    val result = safeEnumValueOf<ContestDataStatus>(this.name)
+    if (result == null) {
+        logger.error { "Vote election type $this has missing or incorrect name" }
+    }
+    return result
+}

--- a/src/commonMain/kotlin/electionguard/ballot/DecryptedTallyOrBallot.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/DecryptedTallyOrBallot.kt
@@ -2,15 +2,16 @@ package electionguard.ballot
 
 import electionguard.core.ElGamalCiphertext
 import electionguard.core.ElementModP
+import electionguard.core.HashedElGamalCiphertext
 import electionguard.decrypt.PartialDecryption
 
 /**
- * The decrypted counts of all contests in the election.
+ * The decrypted counts of all contests in the election, for one ballot or a collection of ballots.
  *
- * @param tallyId the name of the tally. Matches ballotId when its a spoiled ballot decryption.
+ * @param tallyId the name of the tally. Matches ballotId when its a ballot decryption.
  * @param contests The contests, keyed by contest.contestId.
  */
-data class PlaintextTally(val tallyId: String, val contests: Map<String, Contest>) {
+data class DecryptedTallyOrBallot(val tallyId: String, val contests: Map<String, Contest>) {
     /**
      * The decrypted counts of one contest in the election.
      *
@@ -20,10 +21,27 @@ data class PlaintextTally(val tallyId: String, val contests: Map<String, Contest
     data class Contest(
         val contestId: String, // matches ContestDescription.contestId
         val selections: Map<String, Selection>,
+        val decryptedContestData: DecryptedContestData?, // only for ballots
     ) {
         init {
             require(contestId.isNotEmpty())
             require(selections.isNotEmpty())
+        }
+    }
+
+    /**
+     * The decrypted counts of one contest in the election.
+     *
+     * @param contestId equals the Manifest.ContestDescription.contestId.
+     * @param selections The collection of selections in the contest, keyed by selection.selectionId.
+     */
+    data class DecryptedContestData(
+        val contestData: ContestData,
+        val encryptedContestCata : HashedElGamalCiphertext, // same as EncryptedTally.Selection.ciphertext
+        val partialDecryptions: List<PartialDecryption>, // one for each guardian
+    ) {
+        init {
+            require(partialDecryptions.isNotEmpty())
         }
     }
 
@@ -52,7 +70,7 @@ data class PlaintextTally(val tallyId: String, val contests: Map<String, Contest
 
     fun showTally(): String {
         val builder = StringBuilder(5000)
-        builder.appendLine(" Tally $tallyId")
+        builder.appendLine(" DecryptedTallyOrBallot $tallyId")
         contests.values.sortedBy { it.contestId }.forEach { contest ->
             builder.appendLine("  Contest ${contest.contestId}")
             contest.selections.values.sortedBy { it.selectionId }.forEach {

--- a/src/commonMain/kotlin/electionguard/ballot/ElectionResults.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/ElectionResults.kt
@@ -29,7 +29,7 @@ data class TallyResult(
 
 data class DecryptionResult(
     val tallyResult: TallyResult,
-    val decryptedTally: PlaintextTally,
+    val decryptedTallyOrBallot: DecryptedTallyOrBallot,
     val decryptingGuardians: List<DecryptingGuardian>,
     val metadata: Map<String, String> = emptyMap(),
 ) {

--- a/src/commonMain/kotlin/electionguard/ballot/EncryptedBallot.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/EncryptedBallot.kt
@@ -38,6 +38,7 @@ data class EncryptedBallot(
         val selections: List<Selection>,
         val cryptoHash: UInt256,
         val proof: ConstantChaumPedersenProofKnownNonce,
+        val contestData: HashedElGamalCiphertext?,
     )  : CryptoHashableUInt256 {
         init {
             require(contestId.isNotEmpty())
@@ -54,7 +55,6 @@ data class EncryptedBallot(
         val cryptoHash: UInt256,
         val isPlaceholderSelection: Boolean,
         val proof: DisjunctiveChaumPedersenProofKnownNonce,
-        val extendedData: HashedElGamalCiphertext?,
     )  : CryptoHashableUInt256 {
         init {
             require(selectionId.isNotEmpty())

--- a/src/commonMain/kotlin/electionguard/ballot/PlaintextBallot.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/PlaintextBallot.kt
@@ -23,6 +23,7 @@ data class PlaintextBallot(
         val contestId: String, // matches ContestDescription.contestId
         val sequenceOrder: Int,
         val selections: List<Selection>,
+        val writeIns: List<String> = emptyList(),
     ) {
         init {
             require(contestId.isNotEmpty())
@@ -34,7 +35,6 @@ data class PlaintextBallot(
         val selectionId: String, // matches SelectionDescription.selectionId
         val sequenceOrder: Int,
         val vote: Int,
-        val extendedData: String?,
     )  {
         init {
             require(selectionId.isNotEmpty())

--- a/src/commonMain/kotlin/electionguard/decrypt/Decryption.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/Decryption.kt
@@ -4,7 +4,7 @@ import electionguard.ballot.DecryptingGuardian
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.EncryptedTally
 import electionguard.ballot.EncryptedBallot
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.core.ElGamalCiphertext
 import electionguard.core.ElementModQ
 import electionguard.core.GroupContext
@@ -31,12 +31,12 @@ class Decryption(
         result.sortedBy { it.guardianId}
     }
 
-    fun decryptBallot(ballot: EncryptedBallot): PlaintextTally {
+    fun decryptBallot(ballot: EncryptedBallot): DecryptedTallyOrBallot {
         // pretend a ballot is a tally
         return ballot.convertToTally().decrypt()
     }
 
-    fun EncryptedTally.decrypt(): PlaintextTally {
+    fun EncryptedTally.decrypt(): DecryptedTallyOrBallot {
         val shares: MutableList<DecryptionShare> = mutableListOf() // one for each trustee
         for (decryptingTrustee in decryptingTrustees) {
             val share: DecryptionShare = this.computeDecryptionShareForTrustee(decryptingTrustee)

--- a/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithEmbeddedNonces.kt
+++ b/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithEmbeddedNonces.kt
@@ -53,7 +53,6 @@ class DecryptionWithEmbeddedNonces(val publicKey: ElGamalPublicKey) {
                 selection.selectionId,
                 selection.sequenceOrder,
                 decodedVote,
-                null
             )
         }
     }

--- a/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithMasterNonce.kt
+++ b/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithMasterNonce.kt
@@ -92,7 +92,6 @@ class DecryptionWithMasterNonce(val group : GroupContext, val manifest: Manifest
                 selection.selectionId,
                 selection.sequenceOrder,
                 decodedVote,
-                null
             )
         }
     }

--- a/src/commonMain/kotlin/electionguard/encrypt/CiphertextBallot.kt
+++ b/src/commonMain/kotlin/electionguard/encrypt/CiphertextBallot.kt
@@ -27,6 +27,7 @@ data class CiphertextBallot(
         val cryptoHash: UInt256,
         val proof: ConstantChaumPedersenProofKnownNonce,
         val contestNonce: ElementModQ,
+        val contestData: HashedElGamalCiphertext?,
     ) : CryptoHashableUInt256 {
         override fun cryptoHashUInt256() = cryptoHash
     }
@@ -39,7 +40,6 @@ data class CiphertextBallot(
         val cryptoHash: UInt256,
         val isPlaceholderSelection: Boolean,
         val proof: DisjunctiveChaumPedersenProofKnownNonce,
-        val extendedData: HashedElGamalCiphertext?,
         val selectionNonce: ElementModQ,
     ) : CryptoHashableUInt256 {
         override fun cryptoHashUInt256() = cryptoHash
@@ -68,6 +68,7 @@ fun CiphertextBallot.Contest.submit(): EncryptedBallot.Contest {
         this.selections.map { it.submit() },
         this.cryptoHash,
         this.proof,
+        this.contestData,
     )
 }
 
@@ -80,6 +81,5 @@ fun CiphertextBallot.Selection.submit(): EncryptedBallot.Selection {
         this.cryptoHash,
         this.isPlaceholderSelection,
         this.proof,
-        this.extendedData,
     )
 }

--- a/src/commonMain/kotlin/electionguard/encrypt/ContestPrecompute.kt
+++ b/src/commonMain/kotlin/electionguard/encrypt/ContestPrecompute.kt
@@ -136,6 +136,7 @@ class ContestPrecompute(
                 contestNonce,
                 chaumPedersenNonce,
                 encryptedSelections,
+                null, // TODO not handling write-ins
             )
         }
     }
@@ -172,7 +173,6 @@ class ContestPrecompute(
                 disjunctiveChaumPedersenNonce,
                 selectionNonce,
                 isPlaceholder,
-                null, // TODO not handling write-ins
             )
         }
     }

--- a/src/commonMain/kotlin/electionguard/encrypt/SelectionPrecompute.kt
+++ b/src/commonMain/kotlin/electionguard/encrypt/SelectionPrecompute.kt
@@ -124,6 +124,7 @@ class SelectionPrecompute(
                 contestNonce,
                 chaumPedersenNonce,
                 encryptedSelections,
+                null // TODO not handling write-ins
             )
         }
     }
@@ -158,7 +159,6 @@ class SelectionPrecompute(
                 disjunctiveChaumPedersenNonce,
                 selectionNonce,
                 isPlaceholder,
-                null // TODO not handling write-ins
             )
         }
 
@@ -171,7 +171,6 @@ class SelectionPrecompute(
                 disjunctiveChaumPedersenNonce,
                 selectionNonce,
                 isPlaceholder,
-                null // TODO not handling write-ins
             )
         }
 

--- a/src/commonMain/kotlin/electionguard/input/RandomBallotProvider.kt
+++ b/src/commonMain/kotlin/electionguard/input/RandomBallotProvider.kt
@@ -56,7 +56,7 @@ class RandomBallotProvider(election: Manifest, nballots: Int?) {
                 val choice: Boolean = Random.nextBoolean()
                 return PlaintextBallot.Selection(
                     description.selectionId, description.sequenceOrder,
-                    if (choice) 1 else 0, null
+                    if (choice) 1 else 0,
                 )
             }
         }

--- a/src/commonMain/kotlin/electionguard/protoconvert/CommonConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/CommonConvert.kt
@@ -53,6 +53,7 @@ fun GroupContext.importSchnorrProof(proof: electionguard.protogen.SchnorrProof?)
            else SchnorrProof(publicKey, challenge, response)
 }
 
+// LOOK unneeded?
 fun GroupContext.importElGamalPublicKey(
     publicKey: electionguard.protogen.ElementModP?,
 ) : ElGamalPublicKey? {
@@ -109,6 +110,7 @@ fun SchnorrProof.publishSchnorrProof(): electionguard.protogen.SchnorrProof {
         )
 }
 
+// LOOK unneeded?
 fun ElGamalPublicKey.publishElGamalPublicKey() : electionguard.protogen.ElementModP {
     return this.key.publishElementModP()
 }

--- a/src/commonMain/kotlin/electionguard/protoconvert/ElectionResultsConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/ElectionResultsConvert.kt
@@ -36,7 +36,7 @@ fun GroupContext.importTallyResult(tally : electionguard.protogen.TallyResult?):
 fun GroupContext.importDecryptionResult(decrypt : electionguard.protogen.DecryptionResult):
         Result<DecryptionResult, String>  {
     val tallyResult = this.importTallyResult(decrypt.tallyResult)
-    val decryptedTally = this.importPlaintextTally(decrypt.decryptedTally)
+    val decryptedTally = this.importDecryptedTallyOrBallot(decrypt.decryptedTally)
 
     val (guardians, gerrors) =
         decrypt.decryptingGuardians.map { importAvailableGuardian(it) }.partition()
@@ -81,7 +81,7 @@ fun TallyResult.publishTallyResult(): electionguard.protogen.TallyResult {
 fun DecryptionResult.publishDecryptionResult(): electionguard.protogen.DecryptionResult {
     return electionguard.protogen.DecryptionResult(
         this.tallyResult.publishTallyResult(),
-        this.decryptedTally.publishPlaintextTally(),
+        this.decryptedTallyOrBallot.publishDecryptedTallyOrBallot(),
         this.decryptingGuardians.map { it.publishAvailableGuardian() },
         this.metadata.entries.map { electionguard.protogen.DecryptionResult.MetadataEntry(it.key, it.value)}
     )

--- a/src/commonMain/kotlin/electionguard/protoconvert/EncryptedBallotConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/EncryptedBallotConvert.kt
@@ -85,6 +85,7 @@ private fun GroupContext.importContest(
             selections,
             cryptoHash.unwrap(),
             proof.unwrap(),
+            null, // TODO
         )
     )
 }
@@ -117,7 +118,6 @@ private fun GroupContext.importSelection(
     val cryptoHash = importUInt256(selection.cryptoHash)
         .toResultOr {"CiphertextBallotSelection $here cryptoHash was malformed or missing"}
     val proof = this.importDisjunctiveChaumPedersenProof(selection.proof, here)
-    val extendedData = this.importHashedCiphertext(selection.extendedData)
 
     val errors = getAllErrors(proof, selectionHash, ciphertext, cryptoHash)
     if (errors.isNotEmpty()) {
@@ -133,7 +133,6 @@ private fun GroupContext.importSelection(
             cryptoHash.unwrap(),
             selection.isPlaceholderSelection,
             proof.unwrap(),
-            extendedData
         )
     )
 }
@@ -187,6 +186,7 @@ private fun EncryptedBallot.Contest.publishContest():
             this.selections.map { it.publishSelection() },
             this.cryptoHash.publishUInt256(),
             this.proof.let { this.proof.publishConstantChaumPedersenProof() },
+            this.contestData?.let { this.contestData.publishHashedCiphertext() },
         )
 }
 
@@ -201,7 +201,6 @@ private fun EncryptedBallot.Selection.publishSelection():
             this.cryptoHash.publishUInt256(),
             this.isPlaceholderSelection,
             this.proof.let { this.proof.publishDisjunctiveChaumPedersenProof() },
-            this.extendedData?.let { this.extendedData.publishHashedCiphertext() },
         )
 }
 

--- a/src/commonMain/kotlin/electionguard/protoconvert/PlaintextBallotConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/PlaintextBallotConvert.kt
@@ -16,7 +16,8 @@ private fun GroupContext.importContest(contest: electionguard.protogen.Plaintext
     return PlaintextBallot.Contest(
         contest.contestId,
         contest.sequenceOrder,
-        contest.selections.map { importSelection(it) }
+        contest.selections.map { importSelection(it) },
+        contest.writeIns,
     )
 }
 
@@ -26,7 +27,6 @@ private fun importSelection(selection: electionguard.protogen.PlaintextBallotSel
             selection.selectionId,
             selection.sequenceOrder,
             selection.vote,
-            selection.extendedData,
         )
     }
 
@@ -48,8 +48,9 @@ private fun PlaintextBallot.Contest.publishContest():
             .PlaintextBallotContest(
                 this.contestId,
                 this.sequenceOrder,
-                this.selections.map { it.publishSelection() }
-            )
+                this.selections.map { it.publishSelection() },
+                this.writeIns,
+                )
     }
 
 private fun PlaintextBallot.Selection.publishSelection():
@@ -59,6 +60,5 @@ private fun PlaintextBallot.Selection.publishSelection():
                 this.selectionId,
                 this.sequenceOrder,
                 this.vote,
-                this.extendedData?: ""
             )
     }

--- a/src/commonMain/kotlin/electionguard/protogen/common.kt
+++ b/src/commonMain/kotlin/electionguard/protogen/common.kt
@@ -314,6 +314,7 @@ public data class HashedElGamalCiphertext(
 
 @pbandk.Export
 public data class SchnorrProof(
+    val publicKey: electionguard.protogen.ElementModP? = null,
     val challenge: electionguard.protogen.ElementModQ? = null,
     val response: electionguard.protogen.ElementModQ? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -326,13 +327,23 @@ public data class SchnorrProof(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.SchnorrProof = electionguard.protogen.SchnorrProof.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.SchnorrProof> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.SchnorrProof, *>>(2)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.SchnorrProof, *>>(3)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
+                        name = "public_key",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModP.Companion),
+                        jsonName = "publicKey",
+                        value = electionguard.protogen.SchnorrProof::publicKey
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
                         name = "challenge",
-                        number = 3,
+                        number = 2,
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
                         jsonName = "challenge",
                         value = electionguard.protogen.SchnorrProof::challenge
@@ -342,7 +353,7 @@ public data class SchnorrProof(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
                         name = "response",
-                        number = 4,
+                        number = 3,
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
                         jsonName = "response",
                         value = electionguard.protogen.SchnorrProof::response
@@ -555,6 +566,7 @@ public fun SchnorrProof?.orDefault(): electionguard.protogen.SchnorrProof = this
 
 private fun SchnorrProof.protoMergeImpl(plus: pbandk.Message?): SchnorrProof = (plus as? SchnorrProof)?.let {
     it.copy(
+        publicKey = publicKey?.plus(plus.publicKey) ?: plus.publicKey,
         challenge = challenge?.plus(plus.challenge) ?: plus.challenge,
         response = response?.plus(plus.response) ?: plus.response,
         unknownFields = unknownFields + plus.unknownFields
@@ -563,16 +575,18 @@ private fun SchnorrProof.protoMergeImpl(plus: pbandk.Message?): SchnorrProof = (
 
 @Suppress("UNCHECKED_CAST")
 private fun SchnorrProof.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SchnorrProof {
+    var publicKey: electionguard.protogen.ElementModP? = null
     var challenge: electionguard.protogen.ElementModQ? = null
     var response: electionguard.protogen.ElementModQ? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
-            3 -> challenge = _fieldValue as electionguard.protogen.ElementModQ
-            4 -> response = _fieldValue as electionguard.protogen.ElementModQ
+            1 -> publicKey = _fieldValue as electionguard.protogen.ElementModP
+            2 -> challenge = _fieldValue as electionguard.protogen.ElementModQ
+            3 -> response = _fieldValue as electionguard.protogen.ElementModQ
         }
     }
-    return SchnorrProof(challenge, response, unknownFields)
+    return SchnorrProof(publicKey, challenge, response, unknownFields)
 }
 
 @pbandk.Export

--- a/src/commonMain/kotlin/electionguard/protogen/common.kt
+++ b/src/commonMain/kotlin/electionguard/protogen/common.kt
@@ -3,6 +3,81 @@
 package electionguard.protogen
 
 @pbandk.Export
+public data class ContestData(
+    val vote: electionguard.protogen.ContestData.Status = electionguard.protogen.ContestData.Status.fromValue(0),
+    val overVotes: List<Int> = emptyList(),
+    val writeIns: List<String> = emptyList(),
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.ContestData = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.ContestData> get() = Companion.descriptor
+    override val protoSize: Int by lazy { super.protoSize }
+    public companion object : pbandk.Message.Companion<electionguard.protogen.ContestData> {
+        public val defaultInstance: electionguard.protogen.ContestData by lazy { electionguard.protogen.ContestData() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.ContestData = electionguard.protogen.ContestData.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.ContestData> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.ContestData, *>>(3)
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "vote",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = electionguard.protogen.ContestData.Status.Companion),
+                        jsonName = "vote",
+                        value = electionguard.protogen.ContestData::vote
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "over_votes",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
+                        jsonName = "overVotes",
+                        value = electionguard.protogen.ContestData::overVotes
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "write_ins",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                        jsonName = "writeIns",
+                        value = electionguard.protogen.ContestData::writeIns
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                fullName = "ContestData",
+                messageClass = electionguard.protogen.ContestData::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+
+    public sealed class Status(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
+        override fun equals(other: kotlin.Any?): Boolean = other is ContestData.Status && other.value == value
+        override fun hashCode(): Int = value.hashCode()
+        override fun toString(): String = "ContestData.Status.${name ?: "UNRECOGNIZED"}(value=$value)"
+
+        public object NORMAL : Status(0, "normal")
+        public object NULL_VOTE : Status(1, "null_vote")
+        public object UNDER_VOTE : Status(2, "under_vote")
+        public class UNRECOGNIZED(value: Int) : Status(value)
+
+        public companion object : pbandk.Message.Enum.Companion<ContestData.Status> {
+            public val values: List<ContestData.Status> by lazy { listOf(NORMAL, NULL_VOTE, UNDER_VOTE) }
+            override fun fromValue(value: Int): ContestData.Status = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
+            override fun fromName(name: String): ContestData.Status = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No Status with name: $name")
+        }
+    }
+}
+
+@pbandk.Export
 public data class ElementModP(
     val value: pbandk.ByteArr = pbandk.ByteArr.empty,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -239,7 +314,6 @@ public data class HashedElGamalCiphertext(
 
 @pbandk.Export
 public data class SchnorrProof(
-    val publicKey: electionguard.protogen.ElementModP? = null,
     val challenge: electionguard.protogen.ElementModQ? = null,
     val response: electionguard.protogen.ElementModQ? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -252,23 +326,13 @@ public data class SchnorrProof(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.SchnorrProof = electionguard.protogen.SchnorrProof.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.SchnorrProof> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.SchnorrProof, *>>(3)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.SchnorrProof, *>>(2)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
-                        name = "public_key",
-                        number = 1,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModP.Companion),
-                        jsonName = "publicKey",
-                        value = electionguard.protogen.SchnorrProof::publicKey
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
                         name = "challenge",
-                        number = 2,
+                        number = 3,
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
                         jsonName = "challenge",
                         value = electionguard.protogen.SchnorrProof::challenge
@@ -278,7 +342,7 @@ public data class SchnorrProof(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
                         name = "response",
-                        number = 3,
+                        number = 4,
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
                         jsonName = "response",
                         value = electionguard.protogen.SchnorrProof::response
@@ -332,72 +396,31 @@ public data class UInt256(
 }
 
 @pbandk.Export
-public data class ContestData(
-    val overvotes: List<Int> = emptyList(),
-    val underVote: Boolean = false,
-    val nullVote: Boolean = false,
-    val writeIns: List<Int> = emptyList(),
-    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
-) : pbandk.Message {
-    override operator fun plus(other: pbandk.Message?): electionguard.protogen.ContestData = protoMergeImpl(other)
-    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.ContestData> get() = Companion.descriptor
-    override val protoSize: Int by lazy { super.protoSize }
-    public companion object : pbandk.Message.Companion<electionguard.protogen.ContestData> {
-        public val defaultInstance: electionguard.protogen.ContestData by lazy { electionguard.protogen.ContestData() }
-        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.ContestData = electionguard.protogen.ContestData.decodeWithImpl(u)
+@pbandk.JsName("orDefaultForContestData")
+public fun ContestData?.orDefault(): electionguard.protogen.ContestData = this ?: ContestData.defaultInstance
 
-        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.ContestData> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.ContestData, *>>(4)
-            fieldsList.apply {
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "overvotes",
-                        number = 1,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
-                        jsonName = "overvotes",
-                        value = electionguard.protogen.ContestData::overvotes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "under_vote",
-                        number = 2,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(),
-                        jsonName = "underVote",
-                        value = electionguard.protogen.ContestData::underVote
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "null_vote",
-                        number = 3,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(),
-                        jsonName = "nullVote",
-                        value = electionguard.protogen.ContestData::nullVote
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "write_ins",
-                        number = 4,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
-                        jsonName = "writeIns",
-                        value = electionguard.protogen.ContestData::writeIns
-                    )
-                )
-            }
-            pbandk.MessageDescriptor(
-                fullName = "ContestData",
-                messageClass = electionguard.protogen.ContestData::class,
-                messageCompanion = this,
-                fields = fieldsList
-            )
+private fun ContestData.protoMergeImpl(plus: pbandk.Message?): ContestData = (plus as? ContestData)?.let {
+    it.copy(
+        overVotes = overVotes + plus.overVotes,
+        writeIns = writeIns + plus.writeIns,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun ContestData.Companion.decodeWithImpl(u: pbandk.MessageDecoder): ContestData {
+    var vote: electionguard.protogen.ContestData.Status = electionguard.protogen.ContestData.Status.fromValue(0)
+    var overVotes: pbandk.ListWithSize.Builder<Int>? = null
+    var writeIns: pbandk.ListWithSize.Builder<String>? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> vote = _fieldValue as electionguard.protogen.ContestData.Status
+            2 -> overVotes = (overVotes ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<Int> }
+            3 -> writeIns = (writeIns ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<String> }
         }
     }
+    return ContestData(vote, pbandk.ListWithSize.Builder.fixed(overVotes), pbandk.ListWithSize.Builder.fixed(writeIns), unknownFields)
 }
 
 @pbandk.Export
@@ -532,7 +555,6 @@ public fun SchnorrProof?.orDefault(): electionguard.protogen.SchnorrProof = this
 
 private fun SchnorrProof.protoMergeImpl(plus: pbandk.Message?): SchnorrProof = (plus as? SchnorrProof)?.let {
     it.copy(
-        publicKey = publicKey?.plus(plus.publicKey) ?: plus.publicKey,
         challenge = challenge?.plus(plus.challenge) ?: plus.challenge,
         response = response?.plus(plus.response) ?: plus.response,
         unknownFields = unknownFields + plus.unknownFields
@@ -541,18 +563,16 @@ private fun SchnorrProof.protoMergeImpl(plus: pbandk.Message?): SchnorrProof = (
 
 @Suppress("UNCHECKED_CAST")
 private fun SchnorrProof.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SchnorrProof {
-    var publicKey: electionguard.protogen.ElementModP? = null
     var challenge: electionguard.protogen.ElementModQ? = null
     var response: electionguard.protogen.ElementModQ? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
-            1 -> publicKey = _fieldValue as electionguard.protogen.ElementModP
-            2 -> challenge = _fieldValue as electionguard.protogen.ElementModQ
-            3 -> response = _fieldValue as electionguard.protogen.ElementModQ
+            3 -> challenge = _fieldValue as electionguard.protogen.ElementModQ
+            4 -> response = _fieldValue as electionguard.protogen.ElementModQ
         }
     }
-    return SchnorrProof(publicKey, challenge, response, unknownFields)
+    return SchnorrProof(challenge, response, unknownFields)
 }
 
 @pbandk.Export
@@ -575,34 +595,4 @@ private fun UInt256.Companion.decodeWithImpl(u: pbandk.MessageDecoder): UInt256 
         }
     }
     return UInt256(value, unknownFields)
-}
-
-@pbandk.Export
-@pbandk.JsName("orDefaultForContestData")
-public fun ContestData?.orDefault(): electionguard.protogen.ContestData = this ?: ContestData.defaultInstance
-
-private fun ContestData.protoMergeImpl(plus: pbandk.Message?): ContestData = (plus as? ContestData)?.let {
-    it.copy(
-        overvotes = overvotes + plus.overvotes,
-        writeIns = writeIns + plus.writeIns,
-        unknownFields = unknownFields + plus.unknownFields
-    )
-} ?: this
-
-@Suppress("UNCHECKED_CAST")
-private fun ContestData.Companion.decodeWithImpl(u: pbandk.MessageDecoder): ContestData {
-    var overvotes: pbandk.ListWithSize.Builder<Int>? = null
-    var underVote = false
-    var nullVote = false
-    var writeIns: pbandk.ListWithSize.Builder<Int>? = null
-
-    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
-        when (_fieldNumber) {
-            1 -> overvotes = (overvotes ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<Int> }
-            2 -> underVote = _fieldValue as Boolean
-            3 -> nullVote = _fieldValue as Boolean
-            4 -> writeIns = (writeIns ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<Int> }
-        }
-    }
-    return ContestData(pbandk.ListWithSize.Builder.fixed(overvotes), underVote, nullVote, pbandk.ListWithSize.Builder.fixed(writeIns), unknownFields)
 }

--- a/src/commonMain/kotlin/electionguard/protogen/decrypted_tally.kt
+++ b/src/commonMain/kotlin/electionguard/protogen/decrypted_tally.kt
@@ -3,20 +3,20 @@
 package electionguard.protogen
 
 @pbandk.Export
-public data class PlaintextTally(
+public data class DecryptedTallyOrBallot(
     val tallyId: String = "",
-    val contests: List<electionguard.protogen.PlaintextTallyContest> = emptyList(),
+    val contests: List<electionguard.protogen.DecryptedContest> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
-    override operator fun plus(other: pbandk.Message?): electionguard.protogen.PlaintextTally = protoMergeImpl(other)
-    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextTally> get() = Companion.descriptor
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.DecryptedTallyOrBallot = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedTallyOrBallot> get() = Companion.descriptor
     override val protoSize: Int by lazy { super.protoSize }
-    public companion object : pbandk.Message.Companion<electionguard.protogen.PlaintextTally> {
-        public val defaultInstance: electionguard.protogen.PlaintextTally by lazy { electionguard.protogen.PlaintextTally() }
-        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.PlaintextTally = electionguard.protogen.PlaintextTally.decodeWithImpl(u)
+    public companion object : pbandk.Message.Companion<electionguard.protogen.DecryptedTallyOrBallot> {
+        public val defaultInstance: electionguard.protogen.DecryptedTallyOrBallot by lazy { electionguard.protogen.DecryptedTallyOrBallot() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.DecryptedTallyOrBallot = electionguard.protogen.DecryptedTallyOrBallot.decodeWithImpl(u)
 
-        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextTally> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PlaintextTally, *>>(2)
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedTallyOrBallot> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.DecryptedTallyOrBallot, *>>(2)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -25,7 +25,7 @@ public data class PlaintextTally(
                         number = 1,
                         type = pbandk.FieldDescriptor.Type.Primitive.String(),
                         jsonName = "tallyId",
-                        value = electionguard.protogen.PlaintextTally::tallyId
+                        value = electionguard.protogen.DecryptedTallyOrBallot::tallyId
                     )
                 )
                 add(
@@ -33,15 +33,15 @@ public data class PlaintextTally(
                         messageDescriptor = this@Companion::descriptor,
                         name = "contests",
                         number = 2,
-                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.PlaintextTallyContest>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PlaintextTallyContest.Companion)),
+                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.DecryptedContest>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.DecryptedContest.Companion)),
                         jsonName = "contests",
-                        value = electionguard.protogen.PlaintextTally::contests
+                        value = electionguard.protogen.DecryptedTallyOrBallot::contests
                     )
                 )
             }
             pbandk.MessageDescriptor(
-                fullName = "PlaintextTally",
-                messageClass = electionguard.protogen.PlaintextTally::class,
+                fullName = "DecryptedTallyOrBallot",
+                messageClass = electionguard.protogen.DecryptedTallyOrBallot::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -50,20 +50,21 @@ public data class PlaintextTally(
 }
 
 @pbandk.Export
-public data class PlaintextTallyContest(
+public data class DecryptedContest(
     val contestId: String = "",
-    val selections: List<electionguard.protogen.PlaintextTallySelection> = emptyList(),
+    val selections: List<electionguard.protogen.DecryptedSelection> = emptyList(),
+    val decryptedContestData: electionguard.protogen.DecryptedContestData? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
-    override operator fun plus(other: pbandk.Message?): electionguard.protogen.PlaintextTallyContest = protoMergeImpl(other)
-    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextTallyContest> get() = Companion.descriptor
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.DecryptedContest = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedContest> get() = Companion.descriptor
     override val protoSize: Int by lazy { super.protoSize }
-    public companion object : pbandk.Message.Companion<electionguard.protogen.PlaintextTallyContest> {
-        public val defaultInstance: electionguard.protogen.PlaintextTallyContest by lazy { electionguard.protogen.PlaintextTallyContest() }
-        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.PlaintextTallyContest = electionguard.protogen.PlaintextTallyContest.decodeWithImpl(u)
+    public companion object : pbandk.Message.Companion<electionguard.protogen.DecryptedContest> {
+        public val defaultInstance: electionguard.protogen.DecryptedContest by lazy { electionguard.protogen.DecryptedContest() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.DecryptedContest = electionguard.protogen.DecryptedContest.decodeWithImpl(u)
 
-        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextTallyContest> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PlaintextTallyContest, *>>(2)
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedContest> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.DecryptedContest, *>>(3)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -72,7 +73,7 @@ public data class PlaintextTallyContest(
                         number = 1,
                         type = pbandk.FieldDescriptor.Type.Primitive.String(),
                         jsonName = "contestId",
-                        value = electionguard.protogen.PlaintextTallyContest::contestId
+                        value = electionguard.protogen.DecryptedContest::contestId
                     )
                 )
                 add(
@@ -80,15 +81,25 @@ public data class PlaintextTallyContest(
                         messageDescriptor = this@Companion::descriptor,
                         name = "selections",
                         number = 2,
-                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.PlaintextTallySelection>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PlaintextTallySelection.Companion)),
+                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.DecryptedSelection>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.DecryptedSelection.Companion)),
                         jsonName = "selections",
-                        value = electionguard.protogen.PlaintextTallyContest::selections
+                        value = electionguard.protogen.DecryptedContest::selections
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "decrypted_contest_data",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.DecryptedContestData.Companion),
+                        jsonName = "decryptedContestData",
+                        value = electionguard.protogen.DecryptedContest::decryptedContestData
                     )
                 )
             }
             pbandk.MessageDescriptor(
-                fullName = "PlaintextTallyContest",
-                messageClass = electionguard.protogen.PlaintextTallyContest::class,
+                fullName = "DecryptedContest",
+                messageClass = electionguard.protogen.DecryptedContest::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -97,7 +108,65 @@ public data class PlaintextTallyContest(
 }
 
 @pbandk.Export
-public data class PlaintextTallySelection(
+public data class DecryptedContestData(
+    val contestData: electionguard.protogen.ContestData? = null,
+    val encryptedContestData: electionguard.protogen.HashedElGamalCiphertext? = null,
+    val partialDecryptions: List<electionguard.protogen.PartialDecryption> = emptyList(),
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.DecryptedContestData = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedContestData> get() = Companion.descriptor
+    override val protoSize: Int by lazy { super.protoSize }
+    public companion object : pbandk.Message.Companion<electionguard.protogen.DecryptedContestData> {
+        public val defaultInstance: electionguard.protogen.DecryptedContestData by lazy { electionguard.protogen.DecryptedContestData() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.DecryptedContestData = electionguard.protogen.DecryptedContestData.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedContestData> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.DecryptedContestData, *>>(3)
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "contest_data",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ContestData.Companion),
+                        jsonName = "contestData",
+                        value = electionguard.protogen.DecryptedContestData::contestData
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "encrypted_contest_data",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.HashedElGamalCiphertext.Companion),
+                        jsonName = "encryptedContestData",
+                        value = electionguard.protogen.DecryptedContestData::encryptedContestData
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "partial_decryptions",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.PartialDecryption>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PartialDecryption.Companion)),
+                        jsonName = "partialDecryptions",
+                        value = electionguard.protogen.DecryptedContestData::partialDecryptions
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                fullName = "DecryptedContestData",
+                messageClass = electionguard.protogen.DecryptedContestData::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+@pbandk.Export
+public data class DecryptedSelection(
     val selectionId: String = "",
     val tally: Int = 0,
     val value: electionguard.protogen.ElementModP? = null,
@@ -105,15 +174,15 @@ public data class PlaintextTallySelection(
     val partialDecryptions: List<electionguard.protogen.PartialDecryption> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
-    override operator fun plus(other: pbandk.Message?): electionguard.protogen.PlaintextTallySelection = protoMergeImpl(other)
-    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextTallySelection> get() = Companion.descriptor
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.DecryptedSelection = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedSelection> get() = Companion.descriptor
     override val protoSize: Int by lazy { super.protoSize }
-    public companion object : pbandk.Message.Companion<electionguard.protogen.PlaintextTallySelection> {
-        public val defaultInstance: electionguard.protogen.PlaintextTallySelection by lazy { electionguard.protogen.PlaintextTallySelection() }
-        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.PlaintextTallySelection = electionguard.protogen.PlaintextTallySelection.decodeWithImpl(u)
+    public companion object : pbandk.Message.Companion<electionguard.protogen.DecryptedSelection> {
+        public val defaultInstance: electionguard.protogen.DecryptedSelection by lazy { electionguard.protogen.DecryptedSelection() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.DecryptedSelection = electionguard.protogen.DecryptedSelection.decodeWithImpl(u)
 
-        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextTallySelection> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PlaintextTallySelection, *>>(5)
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.DecryptedSelection> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.DecryptedSelection, *>>(5)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -122,7 +191,7 @@ public data class PlaintextTallySelection(
                         number = 1,
                         type = pbandk.FieldDescriptor.Type.Primitive.String(),
                         jsonName = "selectionId",
-                        value = electionguard.protogen.PlaintextTallySelection::selectionId
+                        value = electionguard.protogen.DecryptedSelection::selectionId
                     )
                 )
                 add(
@@ -132,7 +201,7 @@ public data class PlaintextTallySelection(
                         number = 2,
                         type = pbandk.FieldDescriptor.Type.Primitive.UInt32(),
                         jsonName = "tally",
-                        value = electionguard.protogen.PlaintextTallySelection::tally
+                        value = electionguard.protogen.DecryptedSelection::tally
                     )
                 )
                 add(
@@ -142,7 +211,7 @@ public data class PlaintextTallySelection(
                         number = 3,
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModP.Companion),
                         jsonName = "value",
-                        value = electionguard.protogen.PlaintextTallySelection::value
+                        value = electionguard.protogen.DecryptedSelection::value
                     )
                 )
                 add(
@@ -152,7 +221,7 @@ public data class PlaintextTallySelection(
                         number = 4,
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElGamalCiphertext.Companion),
                         jsonName = "message",
-                        value = electionguard.protogen.PlaintextTallySelection::message
+                        value = electionguard.protogen.DecryptedSelection::message
                     )
                 )
                 add(
@@ -162,13 +231,13 @@ public data class PlaintextTallySelection(
                         number = 5,
                         type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.PartialDecryption>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PartialDecryption.Companion)),
                         jsonName = "partialDecryptions",
-                        value = electionguard.protogen.PlaintextTallySelection::partialDecryptions
+                        value = electionguard.protogen.DecryptedSelection::partialDecryptions
                     )
                 )
             }
             pbandk.MessageDescriptor(
-                fullName = "PlaintextTallySelection",
-                messageClass = electionguard.protogen.PlaintextTallySelection::class,
+                fullName = "DecryptedSelection",
+                messageClass = electionguard.protogen.DecryptedSelection::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -384,10 +453,10 @@ public data class RecoveredPartialDecryption(
 }
 
 @pbandk.Export
-@pbandk.JsName("orDefaultForPlaintextTally")
-public fun PlaintextTally?.orDefault(): electionguard.protogen.PlaintextTally = this ?: PlaintextTally.defaultInstance
+@pbandk.JsName("orDefaultForDecryptedTallyOrBallot")
+public fun DecryptedTallyOrBallot?.orDefault(): electionguard.protogen.DecryptedTallyOrBallot = this ?: DecryptedTallyOrBallot.defaultInstance
 
-private fun PlaintextTally.protoMergeImpl(plus: pbandk.Message?): PlaintextTally = (plus as? PlaintextTally)?.let {
+private fun DecryptedTallyOrBallot.protoMergeImpl(plus: pbandk.Message?): DecryptedTallyOrBallot = (plus as? DecryptedTallyOrBallot)?.let {
     it.copy(
         contests = contests + plus.contests,
         unknownFields = unknownFields + plus.unknownFields
@@ -395,49 +464,81 @@ private fun PlaintextTally.protoMergeImpl(plus: pbandk.Message?): PlaintextTally
 } ?: this
 
 @Suppress("UNCHECKED_CAST")
-private fun PlaintextTally.Companion.decodeWithImpl(u: pbandk.MessageDecoder): PlaintextTally {
+private fun DecryptedTallyOrBallot.Companion.decodeWithImpl(u: pbandk.MessageDecoder): DecryptedTallyOrBallot {
     var tallyId = ""
-    var contests: pbandk.ListWithSize.Builder<electionguard.protogen.PlaintextTallyContest>? = null
+    var contests: pbandk.ListWithSize.Builder<electionguard.protogen.DecryptedContest>? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
             1 -> tallyId = _fieldValue as String
-            2 -> contests = (contests ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.PlaintextTallyContest> }
+            2 -> contests = (contests ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.DecryptedContest> }
         }
     }
-    return PlaintextTally(tallyId, pbandk.ListWithSize.Builder.fixed(contests), unknownFields)
+    return DecryptedTallyOrBallot(tallyId, pbandk.ListWithSize.Builder.fixed(contests), unknownFields)
 }
 
 @pbandk.Export
-@pbandk.JsName("orDefaultForPlaintextTallyContest")
-public fun PlaintextTallyContest?.orDefault(): electionguard.protogen.PlaintextTallyContest = this ?: PlaintextTallyContest.defaultInstance
+@pbandk.JsName("orDefaultForDecryptedContest")
+public fun DecryptedContest?.orDefault(): electionguard.protogen.DecryptedContest = this ?: DecryptedContest.defaultInstance
 
-private fun PlaintextTallyContest.protoMergeImpl(plus: pbandk.Message?): PlaintextTallyContest = (plus as? PlaintextTallyContest)?.let {
+private fun DecryptedContest.protoMergeImpl(plus: pbandk.Message?): DecryptedContest = (plus as? DecryptedContest)?.let {
     it.copy(
         selections = selections + plus.selections,
+        decryptedContestData = decryptedContestData?.plus(plus.decryptedContestData) ?: plus.decryptedContestData,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
 
 @Suppress("UNCHECKED_CAST")
-private fun PlaintextTallyContest.Companion.decodeWithImpl(u: pbandk.MessageDecoder): PlaintextTallyContest {
+private fun DecryptedContest.Companion.decodeWithImpl(u: pbandk.MessageDecoder): DecryptedContest {
     var contestId = ""
-    var selections: pbandk.ListWithSize.Builder<electionguard.protogen.PlaintextTallySelection>? = null
+    var selections: pbandk.ListWithSize.Builder<electionguard.protogen.DecryptedSelection>? = null
+    var decryptedContestData: electionguard.protogen.DecryptedContestData? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
             1 -> contestId = _fieldValue as String
-            2 -> selections = (selections ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.PlaintextTallySelection> }
+            2 -> selections = (selections ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.DecryptedSelection> }
+            3 -> decryptedContestData = _fieldValue as electionguard.protogen.DecryptedContestData
         }
     }
-    return PlaintextTallyContest(contestId, pbandk.ListWithSize.Builder.fixed(selections), unknownFields)
+    return DecryptedContest(contestId, pbandk.ListWithSize.Builder.fixed(selections), decryptedContestData, unknownFields)
 }
 
 @pbandk.Export
-@pbandk.JsName("orDefaultForPlaintextTallySelection")
-public fun PlaintextTallySelection?.orDefault(): electionguard.protogen.PlaintextTallySelection = this ?: PlaintextTallySelection.defaultInstance
+@pbandk.JsName("orDefaultForDecryptedContestData")
+public fun DecryptedContestData?.orDefault(): electionguard.protogen.DecryptedContestData = this ?: DecryptedContestData.defaultInstance
 
-private fun PlaintextTallySelection.protoMergeImpl(plus: pbandk.Message?): PlaintextTallySelection = (plus as? PlaintextTallySelection)?.let {
+private fun DecryptedContestData.protoMergeImpl(plus: pbandk.Message?): DecryptedContestData = (plus as? DecryptedContestData)?.let {
+    it.copy(
+        contestData = contestData?.plus(plus.contestData) ?: plus.contestData,
+        encryptedContestData = encryptedContestData?.plus(plus.encryptedContestData) ?: plus.encryptedContestData,
+        partialDecryptions = partialDecryptions + plus.partialDecryptions,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun DecryptedContestData.Companion.decodeWithImpl(u: pbandk.MessageDecoder): DecryptedContestData {
+    var contestData: electionguard.protogen.ContestData? = null
+    var encryptedContestData: electionguard.protogen.HashedElGamalCiphertext? = null
+    var partialDecryptions: pbandk.ListWithSize.Builder<electionguard.protogen.PartialDecryption>? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> contestData = _fieldValue as electionguard.protogen.ContestData
+            2 -> encryptedContestData = _fieldValue as electionguard.protogen.HashedElGamalCiphertext
+            3 -> partialDecryptions = (partialDecryptions ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.PartialDecryption> }
+        }
+    }
+    return DecryptedContestData(contestData, encryptedContestData, pbandk.ListWithSize.Builder.fixed(partialDecryptions), unknownFields)
+}
+
+@pbandk.Export
+@pbandk.JsName("orDefaultForDecryptedSelection")
+public fun DecryptedSelection?.orDefault(): electionguard.protogen.DecryptedSelection = this ?: DecryptedSelection.defaultInstance
+
+private fun DecryptedSelection.protoMergeImpl(plus: pbandk.Message?): DecryptedSelection = (plus as? DecryptedSelection)?.let {
     it.copy(
         value = value?.plus(plus.value) ?: plus.value,
         message = message?.plus(plus.message) ?: plus.message,
@@ -447,7 +548,7 @@ private fun PlaintextTallySelection.protoMergeImpl(plus: pbandk.Message?): Plain
 } ?: this
 
 @Suppress("UNCHECKED_CAST")
-private fun PlaintextTallySelection.Companion.decodeWithImpl(u: pbandk.MessageDecoder): PlaintextTallySelection {
+private fun DecryptedSelection.Companion.decodeWithImpl(u: pbandk.MessageDecoder): DecryptedSelection {
     var selectionId = ""
     var tally = 0
     var value: electionguard.protogen.ElementModP? = null
@@ -463,7 +564,7 @@ private fun PlaintextTallySelection.Companion.decodeWithImpl(u: pbandk.MessageDe
             5 -> partialDecryptions = (partialDecryptions ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.PartialDecryption> }
         }
     }
-    return PlaintextTallySelection(selectionId, tally, value, message,
+    return DecryptedSelection(selectionId, tally, value, message,
         pbandk.ListWithSize.Builder.fixed(partialDecryptions), unknownFields)
 }
 

--- a/src/commonMain/kotlin/electionguard/protogen/election_record.kt
+++ b/src/commonMain/kotlin/electionguard/protogen/election_record.kt
@@ -554,7 +554,7 @@ public data class TallyResult(
 @pbandk.Export
 public data class DecryptionResult(
     val tallyResult: electionguard.protogen.TallyResult? = null,
-    val decryptedTally: electionguard.protogen.PlaintextTally? = null,
+    val decryptedTally: electionguard.protogen.DecryptedTallyOrBallot? = null,
     val decryptingGuardians: List<electionguard.protogen.DecryptingGuardian> = emptyList(),
     val metadata: List<electionguard.protogen.DecryptionResult.MetadataEntry> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -584,7 +584,7 @@ public data class DecryptionResult(
                         messageDescriptor = this@Companion::descriptor,
                         name = "decrypted_tally",
                         number = 2,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PlaintextTally.Companion),
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.DecryptedTallyOrBallot.Companion),
                         jsonName = "decryptedTally",
                         value = electionguard.protogen.DecryptionResult::decryptedTally
                     )
@@ -985,14 +985,14 @@ private fun DecryptionResult.protoMergeImpl(plus: pbandk.Message?): DecryptionRe
 @Suppress("UNCHECKED_CAST")
 private fun DecryptionResult.Companion.decodeWithImpl(u: pbandk.MessageDecoder): DecryptionResult {
     var tallyResult: electionguard.protogen.TallyResult? = null
-    var decryptedTally: electionguard.protogen.PlaintextTally? = null
+    var decryptedTally: electionguard.protogen.DecryptedTallyOrBallot? = null
     var decryptingGuardians: pbandk.ListWithSize.Builder<electionguard.protogen.DecryptingGuardian>? = null
     var metadata: pbandk.ListWithSize.Builder<electionguard.protogen.DecryptionResult.MetadataEntry>? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
             1 -> tallyResult = _fieldValue as electionguard.protogen.TallyResult
-            2 -> decryptedTally = _fieldValue as electionguard.protogen.PlaintextTally
+            2 -> decryptedTally = _fieldValue as electionguard.protogen.DecryptedTallyOrBallot
             3 -> decryptingGuardians = (decryptingGuardians ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.DecryptingGuardian> }
             4 -> metadata = (metadata ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.DecryptionResult.MetadataEntry> }
         }

--- a/src/commonMain/kotlin/electionguard/protogen/encrypted_ballot.kt
+++ b/src/commonMain/kotlin/electionguard/protogen/encrypted_ballot.kt
@@ -151,6 +151,7 @@ public data class EncryptedBallotContest(
     val selections: List<electionguard.protogen.EncryptedBallotSelection> = emptyList(),
     val cryptoHash: electionguard.protogen.UInt256? = null,
     val proof: electionguard.protogen.ConstantChaumPedersenProof? = null,
+    val encryptedContestData: electionguard.protogen.HashedElGamalCiphertext? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): electionguard.protogen.EncryptedBallotContest = protoMergeImpl(other)
@@ -161,7 +162,7 @@ public data class EncryptedBallotContest(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.EncryptedBallotContest = electionguard.protogen.EncryptedBallotContest.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.EncryptedBallotContest> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallotContest, *>>(6)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallotContest, *>>(7)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -223,6 +224,16 @@ public data class EncryptedBallotContest(
                         value = electionguard.protogen.EncryptedBallotContest::proof
                     )
                 )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "encrypted_contest_data",
+                        number = 8,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.HashedElGamalCiphertext.Companion),
+                        jsonName = "encryptedContestData",
+                        value = electionguard.protogen.EncryptedBallotContest::encryptedContestData
+                    )
+                )
             }
             pbandk.MessageDescriptor(
                 fullName = "EncryptedBallotContest",
@@ -243,7 +254,6 @@ public data class EncryptedBallotSelection(
     val cryptoHash: electionguard.protogen.UInt256? = null,
     val isPlaceholderSelection: Boolean = false,
     val proof: electionguard.protogen.DisjunctiveChaumPedersenProof? = null,
-    val extendedData: electionguard.protogen.HashedElGamalCiphertext? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): electionguard.protogen.EncryptedBallotSelection = protoMergeImpl(other)
@@ -254,7 +264,7 @@ public data class EncryptedBallotSelection(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.EncryptedBallotSelection = electionguard.protogen.EncryptedBallotSelection.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.EncryptedBallotSelection> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallotSelection, *>>(8)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallotSelection, *>>(7)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -324,16 +334,6 @@ public data class EncryptedBallotSelection(
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.DisjunctiveChaumPedersenProof.Companion),
                         jsonName = "proof",
                         value = electionguard.protogen.EncryptedBallotSelection::proof
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "extended_data",
-                        number = 8,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.HashedElGamalCiphertext.Companion),
-                        jsonName = "extendedData",
-                        value = electionguard.protogen.EncryptedBallotSelection::extendedData
                     )
                 )
             }
@@ -507,6 +507,7 @@ private fun EncryptedBallotContest.protoMergeImpl(plus: pbandk.Message?): Encryp
         selections = selections + plus.selections,
         cryptoHash = cryptoHash?.plus(plus.cryptoHash) ?: plus.cryptoHash,
         proof = proof?.plus(plus.proof) ?: plus.proof,
+        encryptedContestData = encryptedContestData?.plus(plus.encryptedContestData) ?: plus.encryptedContestData,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -519,6 +520,7 @@ private fun EncryptedBallotContest.Companion.decodeWithImpl(u: pbandk.MessageDec
     var selections: pbandk.ListWithSize.Builder<electionguard.protogen.EncryptedBallotSelection>? = null
     var cryptoHash: electionguard.protogen.UInt256? = null
     var proof: electionguard.protogen.ConstantChaumPedersenProof? = null
+    var encryptedContestData: electionguard.protogen.HashedElGamalCiphertext? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
@@ -528,10 +530,11 @@ private fun EncryptedBallotContest.Companion.decodeWithImpl(u: pbandk.MessageDec
             4 -> selections = (selections ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.EncryptedBallotSelection> }
             6 -> cryptoHash = _fieldValue as electionguard.protogen.UInt256
             7 -> proof = _fieldValue as electionguard.protogen.ConstantChaumPedersenProof
+            8 -> encryptedContestData = _fieldValue as electionguard.protogen.HashedElGamalCiphertext
         }
     }
     return EncryptedBallotContest(contestId, sequenceOrder, contestHash, pbandk.ListWithSize.Builder.fixed(selections),
-        cryptoHash, proof, unknownFields)
+        cryptoHash, proof, encryptedContestData, unknownFields)
 }
 
 @pbandk.Export
@@ -544,7 +547,6 @@ private fun EncryptedBallotSelection.protoMergeImpl(plus: pbandk.Message?): Encr
         ciphertext = ciphertext?.plus(plus.ciphertext) ?: plus.ciphertext,
         cryptoHash = cryptoHash?.plus(plus.cryptoHash) ?: plus.cryptoHash,
         proof = proof?.plus(plus.proof) ?: plus.proof,
-        extendedData = extendedData?.plus(plus.extendedData) ?: plus.extendedData,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -558,7 +560,6 @@ private fun EncryptedBallotSelection.Companion.decodeWithImpl(u: pbandk.MessageD
     var cryptoHash: electionguard.protogen.UInt256? = null
     var isPlaceholderSelection = false
     var proof: electionguard.protogen.DisjunctiveChaumPedersenProof? = null
-    var extendedData: electionguard.protogen.HashedElGamalCiphertext? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
@@ -569,11 +570,10 @@ private fun EncryptedBallotSelection.Companion.decodeWithImpl(u: pbandk.MessageD
             5 -> cryptoHash = _fieldValue as electionguard.protogen.UInt256
             6 -> isPlaceholderSelection = _fieldValue as Boolean
             7 -> proof = _fieldValue as electionguard.protogen.DisjunctiveChaumPedersenProof
-            8 -> extendedData = _fieldValue as electionguard.protogen.HashedElGamalCiphertext
         }
     }
     return EncryptedBallotSelection(selectionId, sequenceOrder, selectionHash, ciphertext,
-        cryptoHash, isPlaceholderSelection, proof, extendedData, unknownFields)
+        cryptoHash, isPlaceholderSelection, proof, unknownFields)
 }
 
 @pbandk.Export

--- a/src/commonMain/kotlin/electionguard/protogen/plaintext_ballot.kt
+++ b/src/commonMain/kotlin/electionguard/protogen/plaintext_ballot.kt
@@ -76,6 +76,7 @@ public data class PlaintextBallotContest(
     val contestId: String = "",
     val sequenceOrder: Int = 0,
     val selections: List<electionguard.protogen.PlaintextBallotSelection> = emptyList(),
+    val writeIns: List<String> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): electionguard.protogen.PlaintextBallotContest = protoMergeImpl(other)
@@ -86,7 +87,7 @@ public data class PlaintextBallotContest(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.PlaintextBallotContest = electionguard.protogen.PlaintextBallotContest.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextBallotContest> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PlaintextBallotContest, *>>(3)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PlaintextBallotContest, *>>(4)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -118,6 +119,16 @@ public data class PlaintextBallotContest(
                         value = electionguard.protogen.PlaintextBallotContest::selections
                     )
                 )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "write_ins",
+                        number = 4,
+                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                        jsonName = "writeIns",
+                        value = electionguard.protogen.PlaintextBallotContest::writeIns
+                    )
+                )
             }
             pbandk.MessageDescriptor(
                 fullName = "PlaintextBallotContest",
@@ -134,7 +145,6 @@ public data class PlaintextBallotSelection(
     val selectionId: String = "",
     val sequenceOrder: Int = 0,
     val vote: Int = 0,
-    val extendedData: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): electionguard.protogen.PlaintextBallotSelection = protoMergeImpl(other)
@@ -145,7 +155,7 @@ public data class PlaintextBallotSelection(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.PlaintextBallotSelection = electionguard.protogen.PlaintextBallotSelection.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PlaintextBallotSelection> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PlaintextBallotSelection, *>>(4)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PlaintextBallotSelection, *>>(3)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -175,16 +185,6 @@ public data class PlaintextBallotSelection(
                         type = pbandk.FieldDescriptor.Type.Primitive.UInt32(),
                         jsonName = "vote",
                         value = electionguard.protogen.PlaintextBallotSelection::vote
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "extended_data",
-                        number = 5,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
-                        jsonName = "extendedData",
-                        value = electionguard.protogen.PlaintextBallotSelection::extendedData
                     )
                 )
             }
@@ -234,6 +234,7 @@ public fun PlaintextBallotContest?.orDefault(): electionguard.protogen.Plaintext
 private fun PlaintextBallotContest.protoMergeImpl(plus: pbandk.Message?): PlaintextBallotContest = (plus as? PlaintextBallotContest)?.let {
     it.copy(
         selections = selections + plus.selections,
+        writeIns = writeIns + plus.writeIns,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -243,15 +244,17 @@ private fun PlaintextBallotContest.Companion.decodeWithImpl(u: pbandk.MessageDec
     var contestId = ""
     var sequenceOrder = 0
     var selections: pbandk.ListWithSize.Builder<electionguard.protogen.PlaintextBallotSelection>? = null
+    var writeIns: pbandk.ListWithSize.Builder<String>? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
             1 -> contestId = _fieldValue as String
             2 -> sequenceOrder = _fieldValue as Int
             3 -> selections = (selections ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.PlaintextBallotSelection> }
+            4 -> writeIns = (writeIns ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<String> }
         }
     }
-    return PlaintextBallotContest(contestId, sequenceOrder, pbandk.ListWithSize.Builder.fixed(selections), unknownFields)
+    return PlaintextBallotContest(contestId, sequenceOrder, pbandk.ListWithSize.Builder.fixed(selections), pbandk.ListWithSize.Builder.fixed(writeIns), unknownFields)
 }
 
 @pbandk.Export
@@ -269,15 +272,13 @@ private fun PlaintextBallotSelection.Companion.decodeWithImpl(u: pbandk.MessageD
     var selectionId = ""
     var sequenceOrder = 0
     var vote = 0
-    var extendedData = ""
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
             1 -> selectionId = _fieldValue as String
             2 -> sequenceOrder = _fieldValue as Int
             3 -> vote = _fieldValue as Int
-            5 -> extendedData = _fieldValue as String
         }
     }
-    return PlaintextBallotSelection(selectionId, sequenceOrder, vote, extendedData, unknownFields)
+    return PlaintextBallotSelection(selectionId, sequenceOrder, vote, unknownFields)
 }

--- a/src/commonMain/kotlin/electionguard/publish/Consumer.kt
+++ b/src/commonMain/kotlin/electionguard/publish/Consumer.kt
@@ -5,7 +5,7 @@ import electionguard.ballot.DecryptionResult
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.PlaintextBallot
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.TallyResult
 import electionguard.core.GroupContext
@@ -28,7 +28,7 @@ expect class Consumer(
     fun iterateEncryptedBallots(filter : ((EncryptedBallot) -> Boolean)? ): Iterable<EncryptedBallot>
     fun iterateCastBallots(): Iterable<EncryptedBallot>
     fun iterateSpoiledBallots(): Iterable<EncryptedBallot>
-    fun iterateSpoiledBallotTallies(): Iterable<PlaintextTally>
+    fun iterateSpoiledBallotTallies(): Iterable<DecryptedTallyOrBallot>
 
     // not part of the election record, private data
     fun iteratePlaintextBallots(ballotDir: String, filter : ((PlaintextBallot) -> Boolean)? ): Iterable<PlaintextBallot>

--- a/src/commonMain/kotlin/electionguard/publish/ElectionRecord.kt
+++ b/src/commonMain/kotlin/electionguard/publish/ElectionRecord.kt
@@ -9,7 +9,7 @@ import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.EncryptedTally
 import electionguard.ballot.Guardian
 import electionguard.ballot.Manifest
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.TallyResult
 import electionguard.core.ElementModP
 import electionguard.core.UInt256
@@ -45,8 +45,8 @@ interface ElectionRecord {
     fun encryptedTally(): EncryptedTally?
     fun tallyResult(): TallyResult?
 
-    fun decryptedTally(): PlaintextTally?
+    fun decryptedTally(): DecryptedTallyOrBallot?
     fun decryptingGuardians(): List<DecryptingGuardian> // may be empty
-    fun spoiledBallotTallies(): Iterable<PlaintextTally> // may be empty
+    fun spoiledBallotTallies(): Iterable<DecryptedTallyOrBallot> // may be empty
     fun decryptionResult(): DecryptionResult?
 }

--- a/src/commonMain/kotlin/electionguard/publish/ElectionRecordFactory.kt
+++ b/src/commonMain/kotlin/electionguard/publish/ElectionRecordFactory.kt
@@ -10,7 +10,7 @@ import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.EncryptedTally
 import electionguard.ballot.Guardian
 import electionguard.ballot.Manifest
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.TallyResult
 import electionguard.core.ElementModP
 import electionguard.core.UInt256
@@ -133,15 +133,15 @@ private class ElectionRecordImpl(val consumer: Consumer, val stage: ElectionReco
         return tallyResult
     }
 
-    override fun decryptedTally(): PlaintextTally? {
-        return decryptionResult?.decryptedTally
+    override fun decryptedTally(): DecryptedTallyOrBallot? {
+        return decryptionResult?.decryptedTallyOrBallot
     }
 
     override fun decryptingGuardians(): List<DecryptingGuardian> {
         return decryptionResult?.decryptingGuardians ?: emptyList()
     }
 
-    override fun spoiledBallotTallies(): Iterable<PlaintextTally> {
+    override fun spoiledBallotTallies(): Iterable<DecryptedTallyOrBallot> {
         return consumer.iterateSpoiledBallotTallies()
     }
 

--- a/src/commonMain/kotlin/electionguard/publish/Publisher.kt
+++ b/src/commonMain/kotlin/electionguard/publish/Publisher.kt
@@ -12,7 +12,7 @@ expect class Publisher(topDir: String, publisherMode: PublisherMode) {
     fun writeDecryptionResult(decryption: DecryptionResult)
 
     fun encryptedBallotSink(): EncryptedBallotSinkIF
-    fun plaintextTallySink(): PlaintextTallySinkIF
+    fun decryptedTallyOrBallotSink(): DecryptedTallyOrBallotSinkIF
 
     fun writePlaintextBallot(outputDir: String, plaintextBallots: List<PlaintextBallot>)
     fun writeTrustee(trusteeDir: String, trustee: KeyCeremonyTrustee)
@@ -23,8 +23,8 @@ interface EncryptedBallotSinkIF {
     fun close()
 }
 
-interface PlaintextTallySinkIF {
-    fun writePlaintextTally(tally: PlaintextTally)
+interface DecryptedTallyOrBallotSinkIF {
+    fun writeDecryptedTallyOrBallot(tally: DecryptedTallyOrBallot)
     fun close()
 }
 

--- a/src/commonMain/kotlin/electionguard/verifier/Verifier.kt
+++ b/src/commonMain/kotlin/electionguard/verifier/Verifier.kt
@@ -6,7 +6,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getAllErrors
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.Manifest
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.core.ElGamalPublicKey
 import electionguard.core.ElementModP
 import electionguard.core.ElementModQ
@@ -148,7 +148,7 @@ class Verifier(val record: ElectionRecord, val nthreads: Int = 11) {
         return verifyBallots.verify(ballots)
     }
 
-    fun verifyDecryptedTally(tally: PlaintextTally): Stats {
+    fun verifyDecryptedTally(tally: DecryptedTallyOrBallot): Stats {
         val verifyTally = VerifyDecryptedTally(group, manifest, jointPublicKey, cryptoExtendedBaseHash, record.guardians())
         return verifyTally.verifyDecryptedTally(tally)
     }

--- a/src/commonMain/kotlin/electionguard/verifier/VerifyDecryptedTally.kt
+++ b/src/commonMain/kotlin/electionguard/verifier/VerifyDecryptedTally.kt
@@ -5,7 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import electionguard.ballot.Guardian
 import electionguard.ballot.Manifest
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.core.ElGamalPublicKey
 import electionguard.core.ElementModP
 import electionguard.core.ElementModQ
@@ -90,7 +90,7 @@ class VerifyDecryptedTally(
 ) {
     val guardianKeys: Map<String, ElementModP> = guardians.associate { it.guardianId to it.publicKey()}
 
-    fun verifyDecryptedTally(tally: PlaintextTally, showTime : Boolean = false): Stats {
+    fun verifyDecryptedTally(tally: DecryptedTallyOrBallot, showTime : Boolean = false): Stats {
         val starting = getSystemTimeInMillis()
 
         var ncontests = 0
@@ -257,7 +257,7 @@ class VerifyDecryptedTally(
      * the corresponding text labels in the ballot coding file.
      * </pre>
      */
-    private fun verifySelectionDecryption(where: String, selection: PlaintextTally.Selection): Result<Boolean, String> {
+    private fun verifySelectionDecryption(where: String, selection: DecryptedTallyOrBallot.Selection): Result<Boolean, String> {
         val errors = mutableListOf<String>()
         for (share in selection.partialDecryptions) {
             val partialDecryptions: Iterable<ElementModP> = selection.partialDecryptions
@@ -279,7 +279,7 @@ class VerifyDecryptedTally(
     }
 
     fun verifySpoiledBallotTallies(
-        ballots: Iterable<PlaintextTally>,
+        ballots: Iterable<DecryptedTallyOrBallot>,
         nthreads: Int,
         showTime: Boolean = false
     ): StatsAccum {
@@ -304,7 +304,7 @@ class VerifyDecryptedTally(
 
     private val globalStat = StatsAccum()
     private var count = 0
-    private fun CoroutineScope.produceTallies(producer: Iterable<PlaintextTally>): ReceiveChannel<PlaintextTally> =
+    private fun CoroutineScope.produceTallies(producer: Iterable<DecryptedTallyOrBallot>): ReceiveChannel<DecryptedTallyOrBallot> =
         produce {
             for (tally in producer) {
                 send(tally)
@@ -318,8 +318,8 @@ class VerifyDecryptedTally(
 
     private fun CoroutineScope.launchVerifier(
         id: Int,
-        input: ReceiveChannel<PlaintextTally>,
-        verify: (PlaintextTally) -> Stats,
+        input: ReceiveChannel<DecryptedTallyOrBallot>,
+        verify: (DecryptedTallyOrBallot) -> Stats,
     ) = launch(Dispatchers.Default) {
         for (tally in input) {
             if (debug) println("$id channel working on ${tally.tallyId}")

--- a/src/commonMain/kotlin/electionguard/verifier/VerifyRecoveredShares.kt
+++ b/src/commonMain/kotlin/electionguard/verifier/VerifyRecoveredShares.kt
@@ -5,7 +5,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getAllErrors
 import electionguard.ballot.DecryptingGuardian
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.core.ElementModP
 import electionguard.core.ElementModQ
 import electionguard.core.GroupContext
@@ -22,12 +22,12 @@ class VerifyRecoveredShares(
 ) {
     val decryptingGuardians : List<DecryptingGuardian>
     val lagrangeCoefficients: Map<String, ElementModQ>
-    val decryptedTally : PlaintextTally
+    val decryptedTallyOrBallot : DecryptedTallyOrBallot
 
     init {
         decryptingGuardians = record.decryptingGuardians()
         lagrangeCoefficients = decryptingGuardians.associate { it.guardianId to it.lagrangeCoordinate }
-        decryptedTally = record.decryptedTally()!!
+        decryptedTallyOrBallot = record.decryptedTally()!!
     }
 
     fun verify(showTime : Boolean = false): Result<Boolean, String> {
@@ -71,7 +71,7 @@ class VerifyRecoveredShares(
     // 10.B Confirm missing tally shares
     private fun verifyShares(): Result<Boolean, String> {
         val errors = mutableListOf<String>()
-        for (contest in decryptedTally.contests.values) {
+        for (contest in decryptedTallyOrBallot.contests.values) {
             for (selection in contest.selections.values) {
                 val id: String = contest.contestId + "-" + selection.selectionId
                 for (partial in selection.partialDecryptions) {

--- a/src/commonMain/proto/common.proto
+++ b/src/commonMain/proto/common.proto
@@ -3,6 +3,20 @@ syntax = "proto3";
 option java_package = "electionguard.protogen";
 option java_outer_classname = "CommonProto";
 
+// strawman for contest data (section 3.3.4)
+// "any text written into one or more write-in text fields, information about overvotes, undervotes, and null
+// votes, and possibly other data about voter selections"
+message ContestData {
+  enum Status {
+    normal = 0;
+    null_vote = 1;
+    under_vote = 2;
+  }
+  Status vote = 1;
+  repeated uint32 over_votes = 2;  // list of selection sequence_number for this contest
+  repeated string write_ins = 3; // list of write_in strings
+}
+
 // A 4096 bit unsigned int, big-endian.
 // A member of the group Z mod P
 message ElementModP {
@@ -46,10 +60,3 @@ message UInt256 {
   bytes value = 1;
 }
 
-// strawman
-message ContestData {
-  repeated uint32 overvotes = 1;  // list of selection sequence_number for this contest
-  bool under_vote = 2;
-  bool null_vote = 3;
-  repeated uint32 write_ins = 4; // list of write_in ids
-}

--- a/src/commonMain/proto/decrypted_tally.proto
+++ b/src/commonMain/proto/decrypted_tally.proto
@@ -3,20 +3,27 @@ syntax = "proto3";
 import "common.proto";
 
 option java_package = "electionguard.protogen";
-option java_outer_classname = "PlaintextTallyProto";
+option java_outer_classname = "DecryptedTallyOrBallotProto";
 
-// Decrypted Tally of some collection of ballots.
-message PlaintextTally {
-  string tally_id = 1;
-  repeated PlaintextTallyContest contests = 2;
+// Decrypted Tally or ballot, eg spoiled ballot or decrypted Ballot for RLA
+message DecryptedTallyOrBallot {
+  string tally_id = 1; // when decrypting ballots, matches EncryptedBallot.ballot_id
+  repeated DecryptedContest contests = 2;
 }
 
-message PlaintextTallyContest {
+message DecryptedContest {
   string contest_id = 1; // matches ContestDescription.contest_id
-  repeated PlaintextTallySelection selections = 2;
+  repeated DecryptedSelection selections = 2;
+  DecryptedContestData decrypted_contest_data = 3; // optional, decrypted ballot only
 }
 
-message PlaintextTallySelection {
+message DecryptedContestData {
+  ContestData contest_data = 1;
+  HashedElGamalCiphertext encrypted_contest_data = 2; // see 3.3.3. matches EncryptedBallotContest
+  repeated PartialDecryption partial_decryptions = 3; // one for each Guardian, available or not
+}
+
+message DecryptedSelection {
   string selection_id = 1; // matches SelectionDescription.selection_id
   uint32 tally = 2;
   ElementModP value = 3; // g^tally or M in the spec.
@@ -37,7 +44,7 @@ message PartialDecryption {
   }
 }
 
-// artifact because oneof cant have repeated fields
+// artifact due to "oneof" cant have repeated fields
 message RecoveredParts {
   repeated RecoveredPartialDecryption fragments = 1;
 }

--- a/src/commonMain/proto/election_record.proto
+++ b/src/commonMain/proto/election_record.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "encrypted_tally.proto";
 import "common.proto";
 import "manifest.proto";
-import "plaintext_tally.proto";
+import "decrypted_tally.proto";
 
 option java_package = "electionguard.protogen";
 option java_outer_classname = "ElectionRecordProto";
@@ -60,7 +60,7 @@ message TallyResult {
 
 message DecryptionResult {
   TallyResult tally_result = 1;
-  PlaintextTally decrypted_tally = 2;
+  DecryptedTallyOrBallot decrypted_tally = 2;
   repeated DecryptingGuardian decrypting_guardians = 3;
   map<string, string> metadata = 4;
 }

--- a/src/commonMain/proto/encrypted_ballot.proto
+++ b/src/commonMain/proto/encrypted_ballot.proto
@@ -33,6 +33,7 @@ message EncryptedBallotContest {
   reserved 5;
   UInt256 crypto_hash = 6;
   ConstantChaumPedersenProof proof = 7;  // The proof the sum of the selections does not exceed the maximum
+  HashedElGamalCiphertext encrypted_contest_data = 8; // see 3.3.3
 }
 
 // Encryption of a specific selection.
@@ -44,7 +45,6 @@ message EncryptedBallotSelection {
   UInt256 crypto_hash = 5;
   bool is_placeholder_selection = 6;
   DisjunctiveChaumPedersenProof proof = 7; // The proof the selection is an encryption of 0 or 1
-  HashedElGamalCiphertext extended_data = 8; // encrypted representation of the extended_data field.
 }
 
 message ConstantChaumPedersenProof {

--- a/src/commonMain/proto/plaintext_ballot.proto
+++ b/src/commonMain/proto/plaintext_ballot.proto
@@ -15,12 +15,11 @@ message PlaintextBallotContest {
   string contest_id = 1; // matches the ContestDescription.contest_id
   uint32 sequence_order = 2;
   repeated PlaintextBallotSelection selections = 3;
+  repeated string write_ins = 4; // used for write-in candidate(s)
 }
 
 message PlaintextBallotSelection {
   string selection_id = 1; // matches the SelectionDescription.selection_id
   uint32 sequence_order = 2;
   uint32 vote = 3;  // 0 or 1
-  reserved 4;
-  string extended_data = 5; // used for write-in candidate value
 }

--- a/src/commonTest/kotlin/electionguard/ballot/FakeManifestProvider.kt
+++ b/src/commonTest/kotlin/electionguard/ballot/FakeManifestProvider.kt
@@ -40,6 +40,6 @@ fun makeContest(contest: Manifest.ContestDescription, selectionIdx: Int): Plaint
 fun makeSelection(selection: Manifest.SelectionDescription): PlaintextBallot.Selection {
     return PlaintextBallot.Selection(
         selection.selectionId, selection.sequenceOrder,
-        1, null
+        1,
     )
 }

--- a/src/commonTest/kotlin/electionguard/encrypt/EncryptionNonceTest.kt
+++ b/src/commonTest/kotlin/electionguard/encrypt/EncryptionNonceTest.kt
@@ -163,7 +163,6 @@ class VerifyEmbeddedNonces(val group : GroupContext, val manifest: Manifest, val
                 selection.selectionId,
                 selection.sequenceOrder,
                 decodedVote,
-                null
             )
         }
     }

--- a/src/commonTest/kotlin/electionguard/encrypt/FakeBallotProvider.kt
+++ b/src/commonTest/kotlin/electionguard/encrypt/FakeBallotProvider.kt
@@ -23,6 +23,6 @@ fun makeContest(contest: Manifest.ContestDescription, selectionIdx: Int): Plaint
 fun makeSelection(selection: Manifest.SelectionDescription): PlaintextBallot.Selection {
     return PlaintextBallot.Selection(
         selection.selectionId, selection.sequenceOrder,
-        1, null
+        1,
     )
 }

--- a/src/commonTest/kotlin/electionguard/input/BallotInputBuilder.kt
+++ b/src/commonTest/kotlin/electionguard/input/BallotInputBuilder.kt
@@ -49,7 +49,7 @@ class BallotInputBuilder internal constructor(val id: String) {
 
         inner class SelectionBuilder internal constructor(private val id: String, private val vote: Int, private val seqOrder : Int? = null) {
             fun build(): PlaintextBallot.Selection {
-                return PlaintextBallot.Selection(id, seqOrder?: seq++, vote, null)
+                return PlaintextBallot.Selection(id, seqOrder?: seq++, vote)
             }
         }
     }

--- a/src/commonTest/kotlin/electionguard/protoconvert/DecryptedTallyOrBallotConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/DecryptedTallyOrBallotConvertTest.kt
@@ -1,7 +1,7 @@
 package electionguard.protoconvert
 
 import com.github.michaelbull.result.getOrThrow
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.core.GroupContext
 import electionguard.core.tinyGroup
 import electionguard.decrypt.PartialDecryption
@@ -11,14 +11,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-class PlaintextTallyConvertTest {
+class DecryptedTallyOrBallotConvertTest {
 
     @Test
-    fun roundtripPlaintextTally() {
+    fun roundtripDecryptedTallyOrBallot() {
         val context = tinyGroup()
         val tally = generateFakeTally(1, context)
-        val proto = tally.publishPlaintextTally()
-        val roundtrip = context.importPlaintextTally(proto).getOrThrow { IllegalStateException(it) }
+        val proto = tally.publishDecryptedTallyOrBallot()
+        val roundtrip = context.importDecryptedTallyOrBallot(proto).getOrThrow { IllegalStateException(it) }
         assertNotNull(roundtrip)
         for (entry in roundtrip.contests) {
             val contest =
@@ -42,30 +42,31 @@ class PlaintextTallyConvertTest {
 
     companion object {
 
-        fun generateFakeTally(seq: Int, context: GroupContext): PlaintextTally {
+        fun generateFakeTally(seq: Int, context: GroupContext): DecryptedTallyOrBallot {
             val contests = List(7) { generateFakeContest(it, context) }
-            return PlaintextTally("tallyId$seq", contests.associate { it.contestId to it })
+            return DecryptedTallyOrBallot("tallyId$seq", contests.associate { it.contestId to it })
         }
 
-        private fun generateFakeContest(cseq: Int, context: GroupContext): PlaintextTally.Contest {
+        private fun generateFakeContest(cseq: Int, context: GroupContext): DecryptedTallyOrBallot.Contest {
             val selections = List(11) { generateFakeSelection(it, context) }
-            return PlaintextTally.Contest(
+            return DecryptedTallyOrBallot.Contest(
                 "contest$cseq",
-                selections.associate { it.selectionId to it }
+                selections.associate { it.selectionId to it },
+                null, // TODO
             )
         }
 
         private fun generateFakeSelection(
             sseq: Int,
             context: GroupContext
-        ): PlaintextTally.Selection {
+        ): DecryptedTallyOrBallot.Selection {
             val dselections = List(11) { generateCiphertextDecryptionSelection(it, context) }
             //         val selectionId: String, // matches SelectionDescription.selectionId
             //        val tally: Int,
             //        val value: ElementModP,
             //        val message: ElGamalCiphertext,
             //        val shares: List<DecryptionShare.CiphertextDecryptionSelection>,
-            return PlaintextTally.Selection(
+            return DecryptedTallyOrBallot.Selection(
                 "selection$sseq",
                 sseq,
                 generateElementModP(context),

--- a/src/commonTest/kotlin/electionguard/protoconvert/DecryptionResultConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/DecryptionResultConvertTest.kt
@@ -19,12 +19,8 @@ class DecryptionResultConvertTest {
         val roundtrip = context.importDecryptionResult(proto).getOrThrow { IllegalStateException(it) }
         assertNotNull(roundtrip)
 
-        //    val tallyResult: TallyResult,
-        //    //    val decryptedTally: PlaintextTally,
-        //    //    val availableGuardians: List<AvailableGuardian>,
-        //    //    val metadata: Map<String, String> = emptyMap()
         assertEquals(roundtrip.tallyResult, electionRecord.tallyResult)
-        assertEquals(roundtrip.decryptedTally, electionRecord.decryptedTally)
+        assertEquals(roundtrip.decryptedTallyOrBallot, electionRecord.decryptedTallyOrBallot)
         assertEquals(roundtrip.decryptingGuardians, electionRecord.decryptingGuardians)
         assertEquals(roundtrip.metadata, electionRecord.metadata)
 
@@ -34,13 +30,9 @@ class DecryptionResultConvertTest {
 }
 
 fun generateDecryptionResult(context: GroupContext): DecryptionResult {
-    //      val tallyResult: TallyResult,
-    //    val decryptedTally: PlaintextTally,
-    //    val availableGuardians: List<AvailableGuardian>,
-    //    val metadata: Map<String, String> = emptyMap()
     return DecryptionResult(
         generateTallyResult(context),
-        PlaintextTallyConvertTest.generateFakeTally(0, context),
+        DecryptedTallyOrBallotConvertTest.generateFakeTally(0, context),
         List(4) { generateDecryptingGuardian(context, it) },
     )
 }

--- a/src/commonTest/kotlin/electionguard/protoconvert/EncryptedBallotConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/EncryptedBallotConvertTest.kt
@@ -73,6 +73,7 @@ class EncryptedBallotConvertTest {
             selections,
             generateUInt256(context),
             generateConstantChaumPedersenProofKnownNonce(context),
+            generateHashedCiphertext(context),
         )
     }
 
@@ -96,7 +97,6 @@ class EncryptedBallotConvertTest {
             generateUInt256(context),
             false,
             generateDisjunctiveChaumPedersenProofKnownNonce(context),
-            generateHashedCiphertext(context),
         )
     }
 }

--- a/src/commonTest/kotlin/electionguard/protoconvert/PlaintextBallotConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/PlaintextBallotConvertTest.kt
@@ -1,7 +1,6 @@
 package electionguard.protoconvert
 
 import electionguard.ballot.PlaintextBallot
-import electionguard.core.GroupContext
 import electionguard.core.productionGroup
 import kotlin.random.Random
 import kotlin.test.Test
@@ -34,7 +33,6 @@ class PlaintextBallotConvertTest {
             "selection$sseq",
             sseq,
             vote,
-            "ExtendedData$sseq",
         )
     }
 

--- a/src/commonTest/kotlin/electionguard/publish/ElectionRecordTest.kt
+++ b/src/commonTest/kotlin/electionguard/publish/ElectionRecordTest.kt
@@ -31,7 +31,7 @@ class ElectionRecordTest {
             assertNotNull(consumerIn)
             val decryption = consumerIn.readDecryptionResult().getOrThrow { IllegalStateException(it) }
             readElectionRecord(decryption)
-            validateTally(decryption.tallyResult.jointPublicKey(), decryption.decryptedTally,
+            validateTally(decryption.tallyResult.jointPublicKey(), decryption.decryptedTallyOrBallot,
                 decryption.numberOfGuardians(), decryption.quorum(), decryption.decryptingGuardians.size)
         }
     }
@@ -45,9 +45,9 @@ class ElectionRecordTest {
         assertEquals("Standard", config.constants.name)
         assertEquals("v0.95", config.manifest.specVersion)
         assertEquals("RunWorkflow", tallyResult.encryptedTally.tallyId)
-        assertEquals("RunWorkflow", decryption.decryptedTally.tallyId)
-        assertNotNull(decryption.decryptedTally)
-        val contests = decryption.decryptedTally.contests
+        assertEquals("RunWorkflow", decryption.decryptedTallyOrBallot.tallyId)
+        assertNotNull(decryption.decryptedTallyOrBallot)
+        val contests = decryption.decryptedTallyOrBallot.contests
         assertNotNull(contests)
         val contest = contests["contest24"]
         assertNotNull(contest)
@@ -60,7 +60,7 @@ class ElectionRecordTest {
         assertTrue(tallyResult.numberOfGuardians() >= decryption.decryptingGuardians.size)
     }
 
-    fun validateTally(jointKey: ElGamalPublicKey, tally: PlaintextTally, nguardians: Int, quorum: Int, navailable: Int) {
+    fun validateTally(jointKey: ElGamalPublicKey, tally: DecryptedTallyOrBallot, nguardians: Int, quorum: Int, navailable: Int) {
         for (contest in tally.contests.values) {
             for (selection in contest.selections.values) {
                 val actual : Int? = jointKey.dLog(selection.value, 100)

--- a/src/commonTest/kotlin/electionguard/verifier/AttackEncryptedBallotTest.kt
+++ b/src/commonTest/kotlin/electionguard/verifier/AttackEncryptedBallotTest.kt
@@ -4,7 +4,7 @@ import electionguard.ballot.ElectionInitialized
 import electionguard.core.productionGroup
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.EncryptedTally
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.core.GroupContext
 import electionguard.core.hashElements
 import electionguard.decrypt.Decryption
@@ -135,7 +135,8 @@ class AttackEncryptedBallotTest {
             contest.contestHash,
             selections2,
             changeCrypto,
-            contest.proof
+            contest.proof,
+            null, // TODO
         )
     }
 
@@ -157,7 +158,7 @@ class AttackEncryptedBallotTest {
             s1.selectionId, s1.sequenceOrder, s1.selectionHash,
             s2.ciphertext,
             changeCryptoHash,
-            s2.isPlaceholderSelection, s2.proof, s2.extendedData,
+            s2.isPlaceholderSelection, s2.proof,
         )
     }
 }
@@ -167,14 +168,14 @@ fun decryptTally(
     encryptedTally: EncryptedTally,
     electionInit: ElectionInitialized,
     decryptingTrustees: List<DecryptingTrusteeIF>,
-): PlaintextTally {
+): DecryptedTallyOrBallot {
     val decryption = Decryption(group, electionInit, decryptingTrustees, emptyList())
     return with(decryption) { encryptedTally.decrypt() }
 }
 
 fun compareTallies(
-    tally1: PlaintextTally,
-    tally2: PlaintextTally,
+    tally1: DecryptedTallyOrBallot,
+    tally2: DecryptedTallyOrBallot,
     diffOnly: Boolean,
 ) {
     println("Compare  ${tally1.tallyId} to ${tally2.tallyId}")

--- a/src/jvmMain/kotlin/electionguard/publish/Consumer.kt
+++ b/src/jvmMain/kotlin/electionguard/publish/Consumer.kt
@@ -5,7 +5,7 @@ import electionguard.ballot.DecryptionResult
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.PlaintextBallot
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.TallyResult
 import electionguard.core.GroupContext
@@ -99,7 +99,7 @@ actual class Consumer actual constructor(
     }
 
     // all tallies in the file
-    actual fun iterateSpoiledBallotTallies(): Iterable<PlaintextTally> {
+    actual fun iterateSpoiledBallotTallies(): Iterable<DecryptedTallyOrBallot> {
         val filename = path.spoiledBallotPath()
         if (!Files.exists(Path.of(filename))) {
             return emptyList()

--- a/src/jvmMain/kotlin/electionguard/publish/Publisher.kt
+++ b/src/jvmMain/kotlin/electionguard/publish/Publisher.kt
@@ -7,7 +7,7 @@ import electionguard.protoconvert.publishDecryptionResult
 import electionguard.protoconvert.publishElectionConfig
 import electionguard.protoconvert.publishElectionInitialized
 import electionguard.protoconvert.publishPlaintextBallot
-import electionguard.protoconvert.publishPlaintextTally
+import electionguard.protoconvert.publishDecryptedTallyOrBallot
 import electionguard.protoconvert.publishEncryptedBallot
 import electionguard.protoconvert.publishTallyResult
 import electionguard.publish.ElectionRecordPath.Companion.DECRYPTION_RESULT_NAME
@@ -187,14 +187,14 @@ actual class Publisher actual constructor(topDir: String, publisherMode: Publish
         }
     }
 
-    actual fun plaintextTallySink(): PlaintextTallySinkIF =
-        PlaintextTallySink(spoiledBallotPath().toString())
+    actual fun decryptedTallyOrBallotSink(): DecryptedTallyOrBallotSinkIF =
+        DecryptedTallyOrBallotSink(spoiledBallotPath().toString())
 
-    inner class PlaintextTallySink(path: String) : PlaintextTallySinkIF {
+    inner class DecryptedTallyOrBallotSink(path: String) : DecryptedTallyOrBallotSinkIF {
         val out: FileOutputStream = FileOutputStream(path)
 
-        override fun writePlaintextTally(tally: PlaintextTally){
-            val ballotProto: pbandk.Message = tally.publishPlaintextTally()
+        override fun writeDecryptedTallyOrBallot(tally: DecryptedTallyOrBallot){
+            val ballotProto: pbandk.Message = tally.publishDecryptedTallyOrBallot()
             writeDelimitedTo(ballotProto, out)
         }
 

--- a/src/jvmMain/kotlin/electionguard/publish/Reader.kt
+++ b/src/jvmMain/kotlin/electionguard/publish/Reader.kt
@@ -10,7 +10,7 @@ import electionguard.ballot.DecryptionResult
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.PlaintextBallot
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.TallyResult
 import electionguard.core.GroupContext
@@ -20,7 +20,7 @@ import electionguard.protoconvert.importDecryptionResult
 import electionguard.protoconvert.importElectionConfig
 import electionguard.protoconvert.importElectionInitialized
 import electionguard.protoconvert.importPlaintextBallot
-import electionguard.protoconvert.importPlaintextTally
+import electionguard.protoconvert.importDecryptedTallyOrBallot
 import electionguard.protoconvert.importEncryptedBallot
 import electionguard.protoconvert.importTallyResult
 import pbandk.decodeFromByteBuffer
@@ -140,7 +140,7 @@ class EncryptedBallotIterator(
 class SpoiledBallotTallyIterator(
     filename: String,
     private val groupContext: GroupContext,
-) : AbstractIterator<PlaintextTally>() {
+) : AbstractIterator<DecryptedTallyOrBallot>() {
     private val input: FileInputStream = FileInputStream(filename)
 
     override fun computeNext() {
@@ -150,8 +150,8 @@ class SpoiledBallotTallyIterator(
             return done()
         }
         val message = input.readNBytes(length)
-        val tallyProto = electionguard.protogen.PlaintextTally.decodeFromByteBuffer(ByteBuffer.wrap(message))
-        val tally = groupContext.importPlaintextTally(tallyProto)
+        val tallyProto = electionguard.protogen.DecryptedTallyOrBallot.decodeFromByteBuffer(ByteBuffer.wrap(message))
+        val tally = groupContext.importDecryptedTallyOrBallot(tallyProto)
         setNext(tally.getOrElse { throw RuntimeException("Tally failed to parse") })
     }
 }

--- a/src/jvmTest/kotlin/electionguard/publish/ContestDataSerializationHmac.kt
+++ b/src/jvmTest/kotlin/electionguard/publish/ContestDataSerializationHmac.kt
@@ -1,0 +1,110 @@
+package electionguard.publish
+
+import electionguard.core.decrypt
+import electionguard.core.elGamalKeyPairFromRandom
+import electionguard.core.getSystemTimeInMillis
+import electionguard.core.hashedElGamalEncrypt
+import electionguard.core.productionGroup
+import electionguard.protoconvert.importHashedCiphertext
+import electionguard.protoconvert.publishHashedCiphertext
+import electionguard.ballot.ContestData
+import electionguard.ballot.ContestDataStatus
+import electionguard.ballot.import
+import org.junit.jupiter.api.Test
+import pbandk.decodeFromByteBuffer
+import pbandk.encodeToStream
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import kotlin.test.assertEquals
+
+class ContestDataSerializationHmac {
+    val context = productionGroup()
+    val keypair = elGamalKeyPairFromRandom(context)
+
+    @Test
+    fun serializeContestData() {
+        println("\nbytes  ContestData")
+        doOne( ContestData(listOf(), listOf()))
+        doOne( ContestData(listOf(), listOf(), ContestDataStatus.null_vote))
+        doOne( ContestData(listOf(), listOf(), ContestDataStatus.under_vote))
+
+        doOne( ContestData(listOf(1,2,3), listOf()))
+        doOne( ContestData(listOf(1,2,3,4), listOf()))
+        doOne( ContestData(listOf(111,211,311), listOf()))
+        doOne( ContestData(listOf(111,211,311,411), listOf()))
+        doOne( ContestData(listOf(111,211,311,411, 511), listOf()))
+
+        doOne( ContestData(listOf(1,2,3,4), listOf(
+            "a string",
+        )))
+
+        doOne( ContestData(listOf(1,2,3,4), listOf(
+            "a long string ",
+        )))
+
+        doOne( ContestData(listOf(1,2,3,4), listOf(
+            "a longer longer longer string",
+        )))
+
+        doOne( ContestData(listOf(1,2,3,4), listOf(
+            "1000000",
+            "a string",
+            "a long string ",
+            "a longer longer longer string",
+            "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+        )))
+        println()
+    }
+
+    fun doOne(contestData: ContestData) {
+        println("")
+        var starting = getSystemTimeInMillis()
+
+        val contestDataProto = contestData.publish()
+        val contestDataBB = serialize(contestDataProto)
+        val contestDataBA = contestDataBB.array()
+        println("  contestDataBB = ${contestDataBB.limit()}")
+
+        // HMAC encryption
+        val hashedElGamalEncrypt = contestDataBA.hashedElGamalEncrypt(keypair.publicKey)
+        println("  hashed = ${hashedElGamalEncrypt.c1.size}")
+        val hashedProto = hashedElGamalEncrypt.publishHashedCiphertext()
+        println("  hashedProto = ${hashedProto.c1.array.size}")
+        val hashedProtoBB = serialize(hashedProto)
+        println("  hashedProtoBB = ${hashedProtoBB.limit()}")
+
+        var took = getSystemTimeInMillis() - starting
+        println(" hashedElGamalEncrypt took $took millisecs")
+        starting = getSystemTimeInMillis()
+
+        // HMAC decryption
+        val hashedProtoRoundtrip = deserializeHashedProto(hashedProtoBB)
+        val hashedRoundtrip = context.importHashedCiphertext(hashedProtoRoundtrip)!!
+        val contestDataBArt = hashedRoundtrip.decrypt(keypair)!!
+        println("  contestDataBArt = ${contestDataBArt.size}")
+
+        // ContestData roundtrip
+        val contestDataProtoRoundtrip = deserializeContestData(ByteBuffer.wrap(contestDataBArt))
+        val contestDataRoundtrip = contestDataProtoRoundtrip.import()
+
+        assertEquals(contestDataRoundtrip, contestData)
+        // println("  ${hashedProtoBB.limit()} = $contestDataRoundtrip")
+
+        took = getSystemTimeInMillis() - starting
+        println(" hashedElGamalDecrypt took $took millisecs")
+    }
+
+    fun deserializeContestData(buffer: ByteBuffer): electionguard.protogen.ContestData {
+        return electionguard.protogen.ContestData.decodeFromByteBuffer(buffer)
+    }
+
+    fun deserializeHashedProto(buffer: ByteBuffer): electionguard.protogen.HashedElGamalCiphertext {
+        return electionguard.protogen.HashedElGamalCiphertext.decodeFromByteBuffer(buffer)
+    }
+
+    fun serialize(proto: pbandk.Message): ByteBuffer {
+        val bb = ByteArrayOutputStream()
+        proto.encodeToStream(bb)
+        return ByteBuffer.wrap(bb.toByteArray())
+    }
+}

--- a/src/jvmTest/kotlin/electionguard/publish/ContestDataSerializationTest.kt
+++ b/src/jvmTest/kotlin/electionguard/publish/ContestDataSerializationTest.kt
@@ -1,0 +1,208 @@
+package electionguard.publish
+
+import electionguard.protogen.ContestData
+import org.junit.jupiter.api.Test
+import pbandk.decodeFromByteBuffer
+import pbandk.encodeToStream
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import kotlin.test.assertEquals
+
+/*
+message ContestData {
+  enum Vote {
+    normal = 0;
+    null_vote = 1;
+    under_vote = 2;
+  }
+  Vote vote = 1;
+  repeated uint32 over_votes = 2;  // list of selection sequence_number for this contest
+  repeated fixed32 write_ins = 3; // list of write_in string hashcodes
+}
+ */
+class ContestDataSerializationTest {
+
+    @Test
+    fun serializeContestData() {
+        println("\nbytes  ContestData")
+        doOne( ContestDataPojo(listOf(), listOf()))
+        doOne( ContestDataPojo(listOf(), listOf(), ContestData.Status.NULL_VOTE))
+        doOne( ContestDataPojo(listOf(), listOf(), ContestData.Status.UNDER_VOTE))
+
+        doOne( ContestDataPojo(listOf(1,2,3), listOf()))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf()))
+        doOne( ContestDataPojo(listOf(111,211,311), listOf()))
+        doOne( ContestDataPojo(listOf(111,211,311,411), listOf()))
+        doOne( ContestDataPojo(listOf(111,211,311,411, 511), listOf()))
+
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(1,2,3,4)))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(100,200,300,400)))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(1000,2000,3000,4000)))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(10000,20000,30000,40000)))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(100000,200000,300000,400000)))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(1000000,2000000,3000000,4000000)))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(1000000,2000000,3000000,4000000,5000000)))
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(1000000,-2000000,3000000,4000000,5000000)))
+
+        doOne( ContestDataPojo(listOf(1,2,3,4), listOf(
+            "1000000".hashCode(),
+            "a string".hashCode(),
+            "a long string ".hashCode(),
+            "a longer longer longer string".hashCode(),
+            "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789".hashCode(),
+        )))
+        println()
+    }
+
+    fun doOne(pojo : ContestDataPojo) {
+        val proto = pojo.publish()
+        val bb = serialize(proto)
+        val protoRoundtrip = deserialize(bb)
+        val roundtrip = protoRoundtrip.import()
+
+        assertEquals( roundtrip, pojo)
+        println("${bb.limit()} = $roundtrip")
+    }
+
+    fun ContestDataPojo.publish(): electionguard.protogen.ContestData {
+        return electionguard.protogen
+            .ContestData(
+                this.voteEnum,
+                this.overvotes,
+                listOf("fake"), // this.writeIns,
+            )
+    }
+
+    fun electionguard.protogen.ContestData.import(): ContestDataPojo {
+        return ContestDataPojo(
+                this.overVotes,
+             listOf(), // this.writeIns,
+             this.vote,
+            )
+    }
+
+    fun serialize(proto: pbandk.Message) : ByteBuffer {
+        val bb = ByteArrayOutputStream()
+        proto.encodeToStream(bb)
+        return ByteBuffer.wrap(bb.toByteArray())
+    }
+
+   fun deserialize(buffer: ByteBuffer) : electionguard.protogen.ContestData {
+       return electionguard.protogen.ContestData.decodeFromByteBuffer(buffer)
+    }
+
+}
+
+data class ContestDataPojo (
+    val overvotes: List<Int>,
+    val writeIns: List<Int>,
+    val voteEnum: ContestData.Status = ContestData.Status.NORMAL,
+)
+
+/*
+// strawman
+message ContestData {
+  enum Vote {
+    normal = 0;
+    null_vote = 1;
+    under_vote = 2;
+  }
+  Vote vote = 1;
+  repeated uint32 over_votes = 2;  // list of selection sequence_number for this contest
+  repeated sint32 write_ins = 3; // list of write_in ids
+}
+
+bytes  ContestData
+0 = ContestDataPojo(overvotes=[], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+2 = ContestDataPojo(overvotes=[], writeIns=[], voteEnum=ContestData.Vote.null_vote(value=1))
+2 = ContestDataPojo(overvotes=[], writeIns=[], voteEnum=ContestData.Vote.under_vote(value=2))
+5 = ContestDataPojo(overvotes=[1, 2, 3], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+6 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+7 = ContestDataPojo(overvotes=[111, 211, 311], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+9 = ContestDataPojo(overvotes=[111, 211, 311, 411], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+11 = ContestDataPojo(overvotes=[111, 211, 311, 411, 511], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+12 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1, 2, 3, 4], voteEnum=ContestData.Vote.normal(value=0))
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[100, 200, 300, 400], voteEnum=ContestData.Vote.normal(value=0))
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000, 2000, 3000, 4000], voteEnum=ContestData.Vote.normal(value=0))
+20 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[10000, 20000, 30000, 40000], voteEnum=ContestData.Vote.normal(value=0))
+20 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[100000, 200000, 300000, 400000], voteEnum=ContestData.Vote.normal(value=0))
+23 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000000, 2000000, 3000000, 4000000], voteEnum=ContestData.Vote.normal(value=0))
+27 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000000, 2000000, 3000000, 4000000, 5000000], voteEnum=ContestData.Vote.normal(value=0))
+27 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000000, -2000000, 3000000, 4000000, 5000000], voteEnum=ContestData.Vote.normal(value=0))
+33 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1958013297, -1007761232, 1587084778, 513679497, -865692041], voteEnum=ContestData.Vote.normal(value=0))
+
+  repeated fixed32 write_ins = 3; // list of write_in ids
+
+bytes  ContestData
+0 = ContestDataPojo(overvotes=[], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+2 = ContestDataPojo(overvotes=[], writeIns=[], voteEnum=ContestData.Vote.null_vote(value=1))
+2 = ContestDataPojo(overvotes=[], writeIns=[], voteEnum=ContestData.Vote.under_vote(value=2))
+5 = ContestDataPojo(overvotes=[1, 2, 3], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+6 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+7 = ContestDataPojo(overvotes=[111, 211, 311], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+9 = ContestDataPojo(overvotes=[111, 211, 311, 411], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+11 = ContestDataPojo(overvotes=[111, 211, 311, 411, 511], writeIns=[], voteEnum=ContestData.Vote.normal(value=0))
+24 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1, 2, 3, 4], voteEnum=ContestData.Vote.normal(value=0))
+24 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[100, 200, 300, 400], voteEnum=ContestData.Vote.normal(value=0))
+24 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000, 2000, 3000, 4000], voteEnum=ContestData.Vote.normal(value=0))
+24 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[10000, 20000, 30000, 40000], voteEnum=ContestData.Vote.normal(value=0))
+24 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[100000, 200000, 300000, 400000], voteEnum=ContestData.Vote.normal(value=0))
+24 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000000, 2000000, 3000000, 4000000], voteEnum=ContestData.Vote.normal(value=0))
+28 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000000, 2000000, 3000000, 4000000, 5000000], voteEnum=ContestData.Vote.normal(value=0))
+28 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1000000, -2000000, 3000000, 4000000, 5000000], voteEnum=ContestData.Vote.normal(value=0))
+28 = ContestDataPojo(overvotes=[1, 2, 3, 4], writeIns=[1958013297, -1007761232, 1587084778, 513679497, -865692041], voteEnum=ContestData.Vote.normal(value=0))
+ */
+
+/*
+  repeated uint32 write_ins = 4; // list of write_in ids
+
+bytes  ContestData
+0 = ContestDataPojo(overvotes=[], underVote=false, nullVote=false, writeIns=[])
+6 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[])
+12 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1, 2, 3, 4])
+14 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=true, nullVote=false, writeIns=[1, 2, 3, 4])
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=true, nullVote=true, writeIns=[1, 2, 3, 4])
+15 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[100, 200, 300, 400])
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000, 2000, 3000, 4000])
+19 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[10000, 20000, 30000, 40000])
+20 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[100000, 200000, 300000, 400000])
+22 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, 2000000, 3000000, 4000000])
+26 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, 2000000, 3000000, 4000000, 5000000])
+28 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, -2000000, 3000000, 4000000, 5000000])
+33 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1958013297, -1007761232, 1587084778, 513679497, -865692041])
+
+  repeated sint32 write_ins = 4; // list of write_in ids
+
+bytes  ContestData
+0 = ContestDataPojo(overvotes=[], underVote=false, nullVote=false, writeIns=[])
+6 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[])
+12 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1, 2, 3, 4])
+14 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=true, nullVote=false, writeIns=[1, 2, 3, 4])
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=true, nullVote=true, writeIns=[1, 2, 3, 4])
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[100, 200, 300, 400])
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000, 2000, 3000, 4000])
+20 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[10000, 20000, 30000, 40000])
+20 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[100000, 200000, 300000, 400000])
+23 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, 2000000, 3000000, 4000000])
+27 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, 2000000, 3000000, 4000000, 5000000])
+27 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, -2000000, 3000000, 4000000, 5000000])
+33 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1958013297, -1007761232, 1587084778, 513679497, -865692041])
+
+  repeated int32 write_ins = 4; // list of write_in ids
+
+bytes  ContestData
+0 = ContestDataPojo(overvotes=[], underVote=false, nullVote=false, writeIns=[])
+6 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[])
+12 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1, 2, 3, 4])
+14 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=true, nullVote=false, writeIns=[1, 2, 3, 4])
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=true, nullVote=true, writeIns=[1, 2, 3, 4])
+15 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[100, 200, 300, 400])
+16 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000, 2000, 3000, 4000])
+19 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[10000, 20000, 30000, 40000])
+20 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[100000, 200000, 300000, 400000])
+22 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, 2000000, 3000000, 4000000])
+26 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, 2000000, 3000000, 4000000, 5000000])
+33 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1000000, -2000000, 3000000, 4000000, 5000000])
+43 = ContestDataPojo(overvotes=[1, 2, 3, 4], underVote=false, nullVote=false, writeIns=[1958013297, -1007761232, 1587084778, 513679497, -865692041])
+
+ */

--- a/src/nativeMain/kotlin/electionguard/publish/Consumer.kt
+++ b/src/nativeMain/kotlin/electionguard/publish/Consumer.kt
@@ -5,7 +5,7 @@ import electionguard.ballot.DecryptionResult
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.PlaintextBallot
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.TallyResult
 import electionguard.core.GroupContext
@@ -72,7 +72,7 @@ actual class Consumer actual constructor(
         }
     }
 
-    actual fun iterateSpoiledBallotTallies(): Iterable<PlaintextTally> {
+    actual fun iterateSpoiledBallotTallies(): Iterable<DecryptedTallyOrBallot> {
         if (!exists(path.spoiledBallotPath())) {
             return emptyList()
         }

--- a/src/nativeMain/kotlin/electionguard/publish/Publisher.kt
+++ b/src/nativeMain/kotlin/electionguard/publish/Publisher.kt
@@ -7,7 +7,7 @@ import electionguard.protoconvert.publishDecryptionResult
 import electionguard.protoconvert.publishElectionConfig
 import electionguard.protoconvert.publishElectionInitialized
 import electionguard.protoconvert.publishPlaintextBallot
-import electionguard.protoconvert.publishPlaintextTally
+import electionguard.protoconvert.publishDecryptedTallyOrBallot
 import electionguard.protoconvert.publishEncryptedBallot
 import electionguard.protoconvert.publishTallyResult
 import io.ktor.utils.io.errors.*
@@ -109,12 +109,12 @@ actual class Publisher actual constructor(private val topDir: String, publisherM
     }
 
     @Throws(IOException::class)
-    fun writeSpoiledBallotTallies(spoiledBallots: Iterable<PlaintextTally>): Boolean {
+    fun writeSpoiledBallotTallies(spoiledBallots: Iterable<DecryptedTallyOrBallot>): Boolean {
         val fileout = path.spoiledBallotPath()
         val file: CPointer<FILE> = openFile(fileout, "wb")
         try {
             spoiledBallots.forEach {
-                val proto = it.publishPlaintextTally()
+                val proto = it.publishDecryptedTallyOrBallot()
                 val buffer = proto.encodeToByteArray()
 
                 val length = writeVlen(file, fileout, buffer.size)
@@ -189,14 +189,14 @@ actual class Publisher actual constructor(private val topDir: String, publisherM
         }
     }
 
-    actual fun plaintextTallySink(): PlaintextTallySinkIF =
-        PlaintextTallySink(path.spoiledBallotPath())
+    actual fun decryptedTallyOrBallotSink(): DecryptedTallyOrBallotSinkIF =
+        DecryptedTallyOrBallotSink(path.spoiledBallotPath())
 
-    private inner class PlaintextTallySink(val fileout: String) : PlaintextTallySinkIF {
+    private inner class DecryptedTallyOrBallotSink(val fileout: String) : DecryptedTallyOrBallotSinkIF {
         val file: CPointer<FILE> = openFile(fileout, "wb")
 
-        override fun writePlaintextTally(tally: PlaintextTally) {
-            val ballotProto: pbandk.Message = tally.publishPlaintextTally()
+        override fun writeDecryptedTallyOrBallot(tally: DecryptedTallyOrBallot) {
+            val ballotProto: pbandk.Message = tally.publishDecryptedTallyOrBallot()
             val buffer = ballotProto.encodeToByteArray()
 
             val length = writeVlen(file, fileout, buffer.size)

--- a/src/nativeMain/kotlin/electionguard/publish/Reader.kt
+++ b/src/nativeMain/kotlin/electionguard/publish/Reader.kt
@@ -9,7 +9,7 @@ import electionguard.ballot.DecryptionResult
 import electionguard.ballot.ElectionConfig
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.PlaintextBallot
-import electionguard.ballot.PlaintextTally
+import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.TallyResult
 import electionguard.core.GroupContext
@@ -19,7 +19,7 @@ import electionguard.protoconvert.importDecryptionResult
 import electionguard.protoconvert.importElectionConfig
 import electionguard.protoconvert.importElectionInitialized
 import electionguard.protoconvert.importPlaintextBallot
-import electionguard.protoconvert.importPlaintextTally
+import electionguard.protoconvert.importDecryptedTallyOrBallot
 import electionguard.protoconvert.importEncryptedBallot
 import electionguard.protoconvert.importTallyResult
 import io.ktor.utils.io.errors.*
@@ -133,7 +133,7 @@ class EncryptedBallotIterator(
 class SpoiledBallotTallyIterator(
     private val groupContext: GroupContext,
     private val filename: String,
-) : AbstractIterator<PlaintextTally>() {
+) : AbstractIterator<DecryptedTallyOrBallot>() {
 
     private val file = openFile(filename, "rb")
 
@@ -144,9 +144,9 @@ class SpoiledBallotTallyIterator(
             return done()
         }
         val message = readFromFile(file, length.toULong(), filename)
-        val tallyProto = electionguard.protogen.PlaintextTally.decodeFromByteArray(message)
-        val tally = groupContext.importPlaintextTally(tallyProto)
-        setNext(tally.getOrElse { throw RuntimeException("PlaintextTally failed to parse") })
+        val tallyProto = electionguard.protogen.DecryptedTallyOrBallot.decodeFromByteArray(message)
+        val tally = groupContext.importDecryptedTallyOrBallot(tallyProto)
+        setNext(tally.getOrElse { throw RuntimeException("DecryptedTallyOrBallot failed to parse") })
     }
 }
 


### PR DESCRIPTION
rename PlaintextTally to DecryptedTallyOrBallot.
rename plaintext_tally.proto to decrypted_tally.proto. Add DecryptedContestData to DecryptedTallyOrBallot.DecryptedContest (not implemented yet) Add ContestData strawman message and class.
move write-ins to the contest, not selection.
Add some sanity tests for serialization.