### PR TITLE
Harden DecryptingTrustee

### DIFF
--- a/src/commonMain/kotlin/electionguard/core/ElGamal.kt
+++ b/src/commonMain/kotlin/electionguard/core/ElGamal.kt
@@ -176,6 +176,12 @@ fun ElGamalCiphertext.computeShare(secretKey: ElementModQ): ElementModP {
     return pad powP secretKey
 }
 
+/** Compute the share of the decryption from the secret key. */
+fun ElementModP.computeShare(secretKey: ElementModQ): ElementModP {
+    compatibleContextOrFail(this, secretKey)
+    return this powP secretKey
+}
+
 fun ElGamalCiphertext.decryptWithShares(publicKey: ElGamalPublicKey, shares: Iterable<ElementModP>): Int? {
     val sharesList = shares.toList()
     val context = compatibleContextOrFail(pad, data, publicKey.key, *(sharesList.toTypedArray())) // shares)

--- a/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrustee.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrustee.kt
@@ -1,11 +1,9 @@
 package electionguard.decrypt
 
-import electionguard.core.ElGamalCiphertext
 import electionguard.core.ElGamalKeypair
 import electionguard.core.ElementModP
 import electionguard.core.ElementModQ
 import electionguard.core.GroupContext
-import electionguard.core.computeShare
 import electionguard.core.decrypt
 import electionguard.core.randomElementModQ
 import electionguard.core.toElementModQ
@@ -21,12 +19,9 @@ data class DecryptingTrustee(
     val xCoordinate: Int,
     // This guardian's private and public key
     val electionKeypair: ElGamalKeypair,
-    // Other guardians' shares of this guardian's secret key, keyed by generating guardian id.
+    // Other guardians' shares of this guardian's secret key, keyed by generating (missing) guardian id.
     val secretKeyShares: Map<String, SecretKeyShare>,
 ) : DecryptingTrusteeIF {
-    // these will be constructed lazily as needed. keyed by missing_id = generating guardian
-    // Pj(ℓ) = value of other's secret polynomial at my coordinate = "my share of other's secret key"
-    private val generatingGuardianValues = mutableMapOf<String, ElementModQ>()
 
     init {
         require(xCoordinate > 0)
@@ -36,46 +31,53 @@ data class DecryptingTrustee(
     override fun xCoordinate(): Int = xCoordinate
     override fun electionPublicKey(): ElementModP = electionKeypair.publicKey.key
 
-    override fun decrypt(
+    private var tm: ElementModQ? = null
+    private fun tm(): ElementModQ = this.tm ?: throw IllegalStateException()
+
+    override fun setMissing(
         group: GroupContext,
         lagrangeCoeff: ElementModQ,
         missingGuardians: List<String>,
-        texts: List<ElGamalCiphertext>,
+    ) : Boolean {
+        if (this.tm != null) {
+            return false // could test they are the same
+        }
+        this.tm = if (missingGuardians.isEmpty()) group.ZERO_MOD_Q else {
+            // compute tm = wi * (Sum j∈V Pj(ℓ)) mod q
+            val pjls = missingGuardians.map { decryptKeyShare(group, it) }
+            val sumPjls = with(group) { pjls.addQ() }
+            lagrangeCoeff * sumPjls
+        }
+        return true
+    }
+
+    // decryption of key share of a missing guardian
+    // encrypted: El(Pj(ℓ)) = spec 1.52, section 3.2.2 eq 14
+    // decrypted = Pj(ℓ) = value of other's secret polynomial at my coordinate = "my share of other's secret key"
+    private fun decryptKeyShare(group: GroupContext, missingGuardianId: String): ElementModQ {
+        val secretKeyShare: SecretKeyShare = this.secretKeyShares[missingGuardianId]
+            ?: throw IllegalStateException("DecryptingTrustee $id missing SecretKeyShare for $missingGuardianId")
+        val byteArray = secretKeyShare.encryptedCoordinate.decrypt(this.electionKeypair.secretKey)
+            ?: throw IllegalStateException("DecryptingTrustee $id couldnt decrypt SecretKeyShare for $missingGuardianId ")
+        return byteArray.toUInt256().toElementModQ(group)
+    }
+
+    override fun decrypt(
+        group: GroupContext,
+        texts: List<ElementModP>,
         nonce: ElementModQ?
     ): List<PartialDecryption> {
         val results: MutableList<PartialDecryption> = mutableListOf()
-        for (ciphertext: ElGamalCiphertext in texts) {
-            val privateKey = this.electionKeypair.secretKey.key
-
-            // ti = (si + wi * Sum(Pj(i))j∈V) (spec 1.52, eg 58)
-            val ti = if (missingGuardians.isEmpty()) privateKey else {
-                val pjls = missingGuardians.map { computeShare(group, it) }
-                val sumPjls = with(group) { pjls.addQ() }
-                privateKey + lagrangeCoeff * sumPjls // ti = (si + wi * (Sum j∈V Pj (i))) mod q
-            }
+        for (text: ElementModP in texts) {
             val u = nonce?: group.randomElementModQ(2)
             val a = group.gPowP(u)
-            val b = ciphertext.pad powP u
-            val Mbari = ciphertext.computeShare(ti) // Mbar_i = A ^ t_i
-            results.add(PartialDecryption(id, Mbari, u, a, b, ti - privateKey))
+            val b = text powP u
+            // ti = (si + wi * Sum(Pj(i))j∈V) (spec 1.52, eg 58)
+            val ti = this.electionKeypair.secretKey.key + tm()
+            val mbari = text powP ti // Mbar_i = A ^ t_i
+            results.add(PartialDecryption(id, mbari, u, a, b))
         }
         return results
-    }
-
-    // lazy decryption of key share.
-    // encrypted: El(Pj(ℓ)) = spec 1.52, section 3.2.2 eq 14
-    // decrypted = Pj(ℓ)
-    private fun computeShare(group: GroupContext, missingGuardianId : String) : ElementModQ {
-        var generatingGuardianValue = this.generatingGuardianValues[missingGuardianId]
-        if (generatingGuardianValue == null) {
-            val secretKeyShare: SecretKeyShare = this.secretKeyShares[missingGuardianId]
-                ?: throw IllegalStateException("compensate_decrypt guardian $id missing SecretKeyShare for $missingGuardianId")
-            val byteArray = secretKeyShare.encryptedCoordinate.decrypt(this.electionKeypair.secretKey)
-                ?: throw IllegalStateException("$id SecretKeyShare for $id couldnt decrypt SecretKeyShare for $missingGuardianId ")
-            generatingGuardianValue = byteArray.toUInt256().toElementModQ(group)
-            this.generatingGuardianValues[missingGuardianId] = generatingGuardianValue
-        }
-        return generatingGuardianValue
     }
 
     override fun challenge(
@@ -83,7 +85,7 @@ data class DecryptingTrustee(
         challenges: List<ChallengeRequest>,
     ): List<ChallengeResponse> {
         return challenges.map {
-            ChallengeResponse(it.id, it.nonce - it.challenge * ( electionKeypair.secretKey.key + it.tm))
+            ChallengeResponse(it.id, it.nonce - it.challenge * ( electionKeypair.secretKey.key + tm()))
         }
     }
 }

--- a/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeIF.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeIF.kt
@@ -17,19 +17,26 @@ interface DecryptingTrusteeIF {
     fun electionPublicKey(): ElementModP
 
     /**
-     * Compute partial decryption(s) of elgamal encryption(s), using spec 1.52 eq 58 and 59.
-     *
+     * Set missing Guardian info. Once set, cannot be changed.
      * @param lagrangeCoeff    the lagrange coefficient for this trustee
      * @param missingGuardians the missing guardians' Ids
-     * @param texts            list of `ElGamalCiphertext` that will be partially decrypted
+     */
+    fun setMissing(
+        group: GroupContext,
+        lagrangeCoeff: ElementModQ,
+        missingGuardians: List<String>,
+    ) : Boolean
+
+    /**
+     * Compute partial decryption(s) of elgamal encryption(s), using spec 1.52 eq 58 and 59.
+     *
+     * @param texts            list of ElementModP that will be partially decrypted
      * @param nonce            an optional nonce to generate the proof
      * @return a list of partial decryptions, in the same order as the texts
      */
     fun decrypt(
         group: GroupContext,
-        lagrangeCoeff: ElementModQ,
-        missingGuardians: List<String>,
-        texts: List<ElGamalCiphertext>,
+        texts: List<ElementModP>,
         nonce: ElementModQ?,
     ): List<PartialDecryption>
 

--- a/src/commonMain/kotlin/electionguard/decrypt/RunTrustedTallyDecryption.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/RunTrustedTallyDecryption.kt
@@ -104,5 +104,5 @@ fun runDecryptTally(
     )
 
     val took = getSystemTimeInMillis() - starting
-    println("Decrypt tally took $took millisecs")
+    println("DecryptTally took $took millisecs")
 }

--- a/src/commonMain/kotlin/electionguard/decrypt/TallyDecryptor.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/TallyDecryptor.kt
@@ -22,7 +22,7 @@ class TallyDecryptor(
     val guardians: List<Guardian>) {
 
     /**
-     * Called after gathering the shares for all available guardians.
+     * Called after gathering the shares for all available trustees.
      * Shares are in a Map keyed by "${contestId}#@${selectionId}"
      */
     fun decryptTally(tally: EncryptedTally, trusteeDecryptions: TrusteeDecryptions): DecryptedTallyOrBallot {

--- a/src/commonMain/kotlin/electionguard/decrypt/TrusteeDecryptions.kt
+++ b/src/commonMain/kotlin/electionguard/decrypt/TrusteeDecryptions.kt
@@ -9,7 +9,6 @@ data class ChallengeRequest(
     val id: String, // contest-selection id
     val challenge: ElementModQ,
     val nonce: ElementModQ,
-    val tm: ElementModQ,
 )
 
 data class ChallengeResponse(
@@ -24,7 +23,6 @@ data class PartialDecryption(
     val u: ElementModQ,
     val a: ElementModP,
     val b: ElementModP,
-    val tm: ElementModQ
 )
 
 class DecryptionResults(

--- a/src/commonMain/kotlin/electionguard/decryptBallot/RunTrustedBallotDecryption.kt
+++ b/src/commonMain/kotlin/electionguard/decryptBallot/RunTrustedBallotDecryption.kt
@@ -111,21 +111,21 @@ fun runDecryptBallots(
     val ballotIter: Iterable<EncryptedBallot> =
         when {
             (decryptSpoiledList == null) -> {
-                println("use all spoiled")
+                println(" use all spoiled")
                 consumerIn.iterateSpoiledBallots()
             }
             (decryptSpoiledList.trim().lowercase() == "all") -> {
-                println("use all")
+                println(" use all")
                 consumerIn.iterateEncryptedBallots { true }
             }
             fileExists(decryptSpoiledList) -> {
-                println("use ballots in file $decryptSpoiledList")
+                println(" use ballots in file $decryptSpoiledList")
                 val wanted: List<String> = fileReadLines(decryptSpoiledList)
                 val wantedTrim: List<String> = wanted.map { it.trim() }
                 consumerIn.iterateEncryptedBallots { wantedTrim.contains(it.ballotId) }
             }
             else -> {
-                println("use ballots in list ${decryptSpoiledList}")
+                println(" use ballots in list ${decryptSpoiledList}")
                 val wanted: List<String> = decryptSpoiledList.split(",")
                 consumerIn.iterateEncryptedBallots {
                     // println(" ballot ${it.ballotId}")
@@ -158,10 +158,11 @@ fun runDecryptBallots(
 
     val took = getSystemTimeInMillis() - starting
     val msecsPerBallot = (took.toDouble() / 1000 / count)
-    println("Decrypt ballots with nthreads = $nthreads took ${took / 1000} secs for $count ballots = $msecsPerBallot secs/ballot")
+    println(" decrypt ballots with nthreads = $nthreads took ${took / 1000} secs for $count ballots = $msecsPerBallot secs/ballot")
     return count
 }
 
+// parallelize over ballots
 // place the ballot reading into its own coroutine
 @OptIn(ExperimentalCoroutinesApi::class)
 private fun CoroutineScope.produceBallots(producer: Iterable<EncryptedBallot>): ReceiveChannel<EncryptedBallot> =

--- a/src/commonTest/kotlin/electionguard/core/HashedElGamalTest.kt
+++ b/src/commonTest/kotlin/electionguard/core/HashedElGamalTest.kt
@@ -27,13 +27,13 @@ class HashedElGamalTest {
                 elementsModQ(group, minimum = 2)
             ) { bytes, kp, nonce ->
                 val ciphertext = bytes.hashedElGamalEncrypt(kp, nonce)
-                val plaintext = ciphertext.decrypt(kp)
 
-                assertNotNull(plaintext, "decryption succeeded")
+                val plaintext = ciphertext.decrypt(kp)
+                assertNotNull(plaintext, "decrypt with secret key failed")
                 assertContentEquals(bytes, plaintext)
 
                 val alsoPlaintext = ciphertext.decryptWithNonce(kp, nonce)
-                assertNotNull(alsoPlaintext, "decryption succeeded")
+                assertNotNull(alsoPlaintext, "decrypt with nonce failed")
                 assertContentEquals(bytes, alsoPlaintext)
             }
         }

--- a/src/commonTest/kotlin/electionguard/decrypt/EncryptDecryptTest.kt
+++ b/src/commonTest/kotlin/electionguard/decrypt/EncryptDecryptTest.kt
@@ -128,12 +128,17 @@ fun testEncryptRecoveredDecrypt(group: GroupContext,
     // once the set of available guardians is determined, the lagrangeCoefficients can be calculated for all decryptions
     val lagrangeCoefficients = available.associate { it.id to group.computeLagrangeCoefficient(it.xCoordinate, coordsPresent) }
 
+    // configure the DecryptingTrustees
+    for (decryptingTrustee in available) {
+        val lc = lagrangeCoefficients[decryptingTrustee.id()]
+            ?: throw RuntimeException("missing available $decryptingTrustee.id()")
+        decryptingTrustee.setMissing(group, lc, missing)
+    }
+
     val shares: List<PartialDecryption> = available.map {
         it.decrypt(
             group,
-            lagrangeCoefficients[it.id]!!,
-            missing,
-            listOf(evote),
+            listOf(evote.pad),
             null,
         )[0]
     }

--- a/src/commonTest/kotlin/electionguard/decryptBallot/RunDecryptBallotsTest.kt
+++ b/src/commonTest/kotlin/electionguard/decryptBallot/RunDecryptBallotsTest.kt
@@ -16,11 +16,12 @@ import kotlin.test.assertEquals
  */
 class RunDecryptBallotsTest {
     @Test
-    fun testDecryptBallotsAll() {
+    fun testDecryptBallotsAllSingleThreaded() {
         val group = productionGroup()
         val inputDir = "src/commonTest/data/runWorkflowAllAvailable"
         val trusteeDir = "src/commonTest/data/runWorkflowAllAvailable/private_data/trustees"
         val outputDir = "testOut/testDecryptingBallotsAll"
+        println("\ntestDecryptBallotsAll")
         val n = runDecryptBallots(
             group,
             inputDir,
@@ -38,10 +39,11 @@ class RunDecryptBallotsTest {
         val inputDir = "src/commonTest/data/runWorkflowSomeAvailable"
         val trusteeDir = "src/commonTest/data/runWorkflowSomeAvailable/private_data/trustees"
         val outputDir = "testOut/testDecryptingBallotsSome"
+        println("\ntestDecryptBallotsSomeFromList")
         val n = runDecryptBallots(
             group, inputDir, outputDir, readDecryptingTrustees(group, inputDir, trusteeDir, 4),
             "ballot-id-1265470130,ballot-id--1899876476,ballot-id--1377297622",
-            11
+            1,
         )
         assertEquals(3, n)
     }
@@ -53,16 +55,18 @@ class RunDecryptBallotsTest {
         val trusteeDir = "src/commonTest/data/runWorkflowSomeAvailable/private_data/trustees"
         val wantBallots = "src/commonTest/data/runWorkflowSomeAvailable/private_data/wantedBallots.txt"
         val outputDir = "testOut/testDecryptingBallotsSome"
+        println("\ntestDecryptBallotsSomeFromFile")
         val n = runDecryptBallots(
             group, inputDir, outputDir, readDecryptingTrustees(group, inputDir, trusteeDir, 3),
             wantBallots,
-            11,
+            1,
         )
         assertEquals(2, n)
     }
 
     @Test
-    fun testDecryptBallotsMain() {
+    fun testDecryptBallotsMainMultiThreaded() {
+        println("\ntestDecryptBallotsMain")
         main(
             arrayOf(
                 "-in",
@@ -71,6 +75,10 @@ class RunDecryptBallotsTest {
                 "src/commonTest/data/runWorkflowSomeAvailable/private_data/trustees",
                 "-out",
                 "testOut/testDecryptingBallotsSome",
+                "-spoiled",
+                "all",
+                "-nthreads",
+                "6"
             )
         )
     }


### PR DESCRIPTION
DecryptingTrustee.decrypt() works on ElementModP, instead of ElGamalCiphertext, to unify with ContestData decryption.
Precompute tm = wi * (Sum j∈V Pj(ℓ)) mod q, for each trustee i, dont have to pass around tm.
Harden DecryptingTrustee for concurrent access: add DecryptingTrustee.setMissing().