### PR TITLE
Make sure enum conversion doesnt throw an Exception, and errors are logged.

### DIFF
--- a/docs/InputValidation.md
+++ b/docs/InputValidation.md
@@ -1,5 +1,5 @@
 # 🗳 EKM Input Validation
-_last changed: Aug 10, 2022_
+_last changed: Oct 28, 2022_
 
 The election manifest and each input plaintext ballot are expected to be validated before being passed to the 
 EKM library. 
@@ -53,13 +53,11 @@ For additional safety, Manifest Validation may be run during other workflow step
 
 1. A ContestDescription has VoteVariationType = n_of_m, one_of_m, or approval.
 
-2. For all contests, votes_allowed == number_elected.
+2. A one_of_m contest has votes_allowed == 1.
 
-3. A one_of_m contest has votes_allowed == 1.
+3. A n_of_m contest has 0 < votes_allowed <= number of selections in the contest. 
 
-4. A n_of_m contest has 0 < votes_allowed <= number of selections in the contest. 
-
-5. An approval contest has votes_allowed == number of selections in the contest.
+4. An approval contest has votes_allowed == number of selections in the contest.
 
 
 ## Input Ballot

--- a/src/commonMain/kotlin/electionguard/ballot/ContestData.kt
+++ b/src/commonMain/kotlin/electionguard/ballot/ContestData.kt
@@ -171,13 +171,18 @@ fun electionguard.protogen.ContestData.import(): ContestData {
 }
 
 private fun ContestDataStatus.publishContestDataStatus(): electionguard.protogen.ContestData.Status {
-    return electionguard.protogen.ContestData.Status.fromName(this.name)
+    return try {
+        electionguard.protogen.ContestData.Status.fromName(this.name)
+    }  catch (e: IllegalArgumentException) {
+        logger.error { "ContestDataStatus $this has missing or unknown name" }
+        electionguard.protogen.ContestData.Status.NORMAL
+    }
 }
 
 private fun electionguard.protogen.ContestData.Status.importContestDataStatus(): ContestDataStatus? {
     val result = safeEnumValueOf<ContestDataStatus>(this.name)
     if (result == null) {
-        logger.error { "Vote election type $this has missing or incorrect name" }
+        logger.error { "ContestDataStatus $this has missing or unknown name" }
     }
     return result
 }

--- a/src/commonMain/kotlin/electionguard/input/ManifestInputValidation.kt
+++ b/src/commonMain/kotlin/electionguard/input/ManifestInputValidation.kt
@@ -112,21 +112,15 @@ class ManifestInputValidation(val manifest: Manifest) {
             }
         }
 
-        if (contest.numberElected != contest.votesAllowed) {
-            val msg = "Manifest.C.2 Contest's numberElected $contest.numberElected != $contest.votesAllowed votesAllowed"
-            contestMesses.add(msg)
-            logger.warn { msg }
-        }
-
         when (contest.voteVariation) {
             one_of_m -> if (contest.votesAllowed != 1) {
-                val msg = "Manifest.C.3 one_of_m Contest votesAllowed (${contest.votesAllowed}) must be 1"
+                val msg = "Manifest.C.2 one_of_m Contest votesAllowed (${contest.votesAllowed}) must be 1"
                 contestMesses.add(msg)
                 logger.warn { msg }
             }
             n_of_m -> {
                 if (contest.votesAllowed > contest.selections.size) {
-                    val msg = "Manifest.C.4 n_of_m Contest votesAllowed (${contest.votesAllowed}) must be <= selections" +
+                    val msg = "Manifest.C.3 n_of_m Contest votesAllowed (${contest.votesAllowed}) must be <= selections" +
                             " (${contest.selections.size})"
                     contestMesses.add(msg)
                     logger.warn { msg }
@@ -134,7 +128,7 @@ class ManifestInputValidation(val manifest: Manifest) {
             }
             approval -> {
                 if (contest.votesAllowed != contest.selections.size) {
-                    val msg = "Manifest.C.5 approval Contest votesAllowed (${contest.votesAllowed}) must equal " +
+                    val msg = "Manifest.C.4 approval Contest votesAllowed (${contest.votesAllowed}) must equal " +
                             "number of selections (${contest.selections.size})"
                     contestMesses.add(msg)
                     logger.warn { msg }

--- a/src/commonMain/kotlin/electionguard/protoconvert/CommonConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/CommonConvert.kt
@@ -1,17 +1,16 @@
 package electionguard.protoconvert
 
 import electionguard.core.*
-import electionguard.core.ElGamalPublicKey
 import pbandk.ByteArr
 
 fun GroupContext.importElementModQ(modQ: electionguard.protogen.ElementModQ?): ElementModQ? =
-    if (modQ == null) null else this.binaryToElementModQ(modQ.value.array)
+    modQ?.let { this.binaryToElementModQ(modQ.value.array) }
 
 fun importUInt256(modQ: electionguard.protogen.UInt256?): UInt256? =
     modQ?.value?.array?.toUInt256()
 
 fun GroupContext.importElementModP(modP: electionguard.protogen.ElementModP?): ElementModP? =
-    if (modP == null) null else this.binaryToElementModP(modP.value.array)
+    modP?.let { this.binaryToElementModP(modP.value.array) }
 
 fun GroupContext.importCiphertext(
     ciphertext: electionguard.protogen.ElGamalCiphertext?,
@@ -19,7 +18,6 @@ fun GroupContext.importCiphertext(
     if (ciphertext == null) return null
     val pad = this.importElementModP(ciphertext.pad)
     val data = this.importElementModP(ciphertext.data)
-
     return if (pad == null || data == null) null else ElGamalCiphertext(pad, data)
 }
 
@@ -29,7 +27,6 @@ fun GroupContext.importChaumPedersenProof(
     if (proof == null) return null
     val challenge = this.importElementModQ(proof.challenge)
     val response = this.importElementModQ(proof.response)
-
     return if (challenge == null || response == null) null else GenericChaumPedersenProof(challenge, response)
 }
 
@@ -40,16 +37,6 @@ fun GroupContext.importHashedCiphertext(
     val c0 = this.importElementModP(ciphertext.c0)
     val c2 = importUInt256(ciphertext.c2)
     return if (c0 == null || c2 == null) null else HashedElGamalCiphertext(c0, ciphertext.c1.array, c2, ciphertext.numBytes)
-}
-
-// LOOK unneeded?
-fun GroupContext.importElGamalPublicKey(
-    publicKey: electionguard.protogen.ElementModP?,
-) : ElGamalPublicKey? {
-    if (publicKey == null) return null
-    val key = this.importElementModP(publicKey)
-
-    return if (key == null) null else ElGamalPublicKey(key)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -88,9 +75,4 @@ fun HashedElGamalCiphertext.publishHashedCiphertext() :
         this.c2.publishUInt256(),
         this.numBytes,
     )
-}
-
-// LOOK unneeded?
-fun ElGamalPublicKey.publishElGamalPublicKey() : electionguard.protogen.ElementModP {
-    return this.key.publishElementModP()
 }

--- a/src/commonMain/kotlin/electionguard/protoconvert/ManifestFromProto.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/ManifestFromProto.kt
@@ -20,8 +20,8 @@ fun importManifest(manifest: electionguard.protogen.Manifest?):
         manifest.electionScopeId,
         manifest.specVersion,
         manifest.electionType.importElectionType() ?: Manifest.ElectionType.unknown,
-        manifest.startDate, // LocalDateTime.parse(this.startDate),
-        manifest.endDate, // LocalDateTime.parse(this.endDate),
+        manifest.startDate,
+        manifest.endDate,
         manifest.geopoliticalUnits.map { it.importGeopoliticalUnit() },
         manifest.parties.map { it.importParty() },
         manifest.candidates.map { it.importCandidate() },
@@ -87,7 +87,7 @@ private fun electionguard.protogen.ContestDescription.VoteVariationType.importVo
         Manifest.VoteVariationType? {
     val result = safeEnumValueOf<Manifest.VoteVariationType>(this.name)
     if (result == null) {
-        logger.error { "Vote variation type $this has missing or incorrect name" }
+        logger.error { "Manifest.VoteVariationType $this has missing or unknown name" }
     }
     return result
 }
@@ -96,7 +96,7 @@ private fun electionguard.protogen.Manifest.ElectionType.importElectionType():
         Manifest.ElectionType? {
     val result = safeEnumValueOf<Manifest.ElectionType>(this.name)
     if (result == null) {
-        logger.error { "Vote election type $this has missing or incorrect name" }
+        logger.error { "Manifest.ElectionType $this has missing or unknown name" }
     }
     return result
 }
@@ -105,7 +105,7 @@ private fun electionguard.protogen.GeopoliticalUnit.ReportingUnitType.importRepo
         Manifest.ReportingUnitType? {
     val result = safeEnumValueOf<Manifest.ReportingUnitType>(this.name)
     if (result == null) {
-        logger.error { "Reporting unit type $this has missing or incorrect name" }
+        logger.error { "Manifest.ReportingUnitType $this has missing or unknown name" }
     }
     return result
 }
@@ -114,7 +114,7 @@ private fun electionguard.protogen.GeopoliticalUnit.importGeopoliticalUnit(): Ma
     return Manifest.GeopoliticalUnit(
         this.geopoliticalUnitId,
         this.name,
-        this.type.importReportingUnitType() ?: Manifest.ReportingUnitType.unknown, // TODO ok?
+        this.type.importReportingUnitType() ?: Manifest.ReportingUnitType.unknown,
         this.contactInformation?.let { this.contactInformation.importContactInformation() },
     )
 }

--- a/src/commonMain/kotlin/electionguard/protoconvert/ManifestToProto.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/ManifestToProto.kt
@@ -1,6 +1,9 @@
 package electionguard.protoconvert
 
 import electionguard.ballot.Manifest
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger("ManifestToProto")
 
 fun Manifest.publishManifest(): electionguard.protogen.Manifest {
     return electionguard.protogen
@@ -79,17 +82,32 @@ private fun Manifest.ContestDescription.publishContestDescription():
 
 private fun Manifest.VoteVariationType.publishVoteVariationType():
     electionguard.protogen.ContestDescription.VoteVariationType {
-        return electionguard.protogen.ContestDescription.VoteVariationType.fromName(this.name)
+        return try {
+            electionguard.protogen.ContestDescription.VoteVariationType.fromName(this.name)
+        } catch (e: IllegalArgumentException) {
+            logger.error { "Manifest.VoteVariationType $this has missing or unknown name" }
+            electionguard.protogen.ContestDescription.VoteVariationType.UNKNOWN
+        }
     }
 
 private fun Manifest.ElectionType.publishElectionType():
     electionguard.protogen.Manifest.ElectionType {
-        return electionguard.protogen.Manifest.ElectionType.fromName(this.name)
+        return try {
+            electionguard.protogen.Manifest.ElectionType.fromName(this.name)
+        } catch (e: IllegalArgumentException) {
+            logger.error { "Manifest.ElectionType $this has missing or unknown name" }
+            electionguard.protogen.Manifest.ElectionType.UNKNOWN
+        }
     }
 
 private fun Manifest.ReportingUnitType.publishReportingUnitType():
     electionguard.protogen.GeopoliticalUnit.ReportingUnitType {
-        return electionguard.protogen.GeopoliticalUnit.ReportingUnitType.fromName(this.name)
+        return try {
+            electionguard.protogen.GeopoliticalUnit.ReportingUnitType.fromName(this.name)
+        } catch (e: IllegalArgumentException) {
+            logger.error { "Manifest.GeopoliticalUnit $this has missing or unknown name" }
+            electionguard.protogen.GeopoliticalUnit.ReportingUnitType.UNKNOWN
+        }
     }
 
 private fun Manifest.GeopoliticalUnit.publishGeopoliticalUnit():

--- a/src/commonTest/kotlin/electionguard/input/ManifestInputBuilder.kt
+++ b/src/commonTest/kotlin/electionguard/input/ManifestInputBuilder.kt
@@ -96,13 +96,15 @@ class ManifestInputBuilder(val manifestName: String) {
         private val selections = ArrayList<SelectionBuilder>()
         private var type: Manifest.VoteVariationType = Manifest.VoteVariationType.one_of_m
         private var allowed = 1
+        private var number_elected = 1
         private var district: String = districtDefault
         private val name = "name"
 
-        fun setVoteVariationType(type: Manifest.VoteVariationType, allowed: Int): ContestBuilder {
+        fun setVoteVariationType(type: Manifest.VoteVariationType, allowed: Int, number_elected: Int? = null): ContestBuilder {
             require(allowed > 0)
             this.type = type
-            this.allowed = if (type === Manifest.VoteVariationType.one_of_m) 1 else allowed
+            this.allowed = allowed
+            this.number_elected = number_elected?: allowed
             return this
         }
 
@@ -135,14 +137,6 @@ class ManifestInputBuilder(val manifestName: String) {
         }
 
         fun build(): Manifest.ContestDescription {
-            require(selections.size > 0)
-            if (type === Manifest.VoteVariationType.approval) {
-                allowed = selections.size
-            }
-            if (type === Manifest.VoteVariationType.n_of_m) {
-                require(allowed <= selections.size)
-            }
-
             // String contestId,
             //                              String electoral_district_id,
             //                              int sequence_order,
@@ -155,7 +149,7 @@ class ManifestInputBuilder(val manifestName: String) {
             //                              @Nullable InternationalizedText ballot_subtitle
             return Manifest.ContestDescription(
                 id, seq, district,
-                type, allowed, allowed, name,
+                type, allowed, number_elected, name,
                 selections.map { it.build() },
                 null, null, emptyList(),
             )

--- a/src/commonTest/kotlin/electionguard/input/ManifestInputValidationTest.kt
+++ b/src/commonTest/kotlin/electionguard/input/ManifestInputValidationTest.kt
@@ -18,7 +18,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertFalse(problems.hasErrors())
     }
 
@@ -34,7 +34,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.A.1")
         assertContains(problems.toString(), "Manifest.A.5")
@@ -51,7 +51,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.A.2")
     }
@@ -68,7 +68,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.A.3")
         assertContains(problems.toString(), "Manifest.A.5")
@@ -85,7 +85,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.A.4")
     }
@@ -104,7 +104,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.B.1")
         assertContains(problems.toString(), "Manifest.B.6")
@@ -125,7 +125,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.B.2")
         assertContains(problems.toString(), "Manifest.B.4")
@@ -141,7 +141,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.B.6")
         assertContains(problems.toString(), "Manifest.B.3")
@@ -161,7 +161,7 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.B.6")
     }
@@ -176,10 +176,73 @@ class TestManifestInputValidation {
             .build()
         val validator = ManifestInputValidation(election)
         val problems : ValidationMessages = validator.validate()
-        println("Problems=%n$problems")
+        println("Problems=$problems")
         assertTrue(problems.hasErrors())
         assertContains(problems.toString(), "Manifest.B.5")
     }
 
-    // TODO C.1 - C.5
+    @Test
+    fun testUnusedVoteType() {
+        val ebuilder = ManifestInputBuilder("test_manifest")
+        val election: Manifest = ebuilder.addContest("contest_id")
+            .setVoteVariationType(Manifest.VoteVariationType.proportional, 1)
+            .addSelection("selection_id", "candidate_1")
+            .addSelection("selection_id2", "candidate_2")
+            .done()
+            .build()
+        val validator = ManifestInputValidation(election)
+        val problems : ValidationMessages = validator.validate()
+        println("Problems=$problems")
+        assertTrue(problems.hasErrors())
+        assertContains(problems.toString(), "Manifest.C.1")
+    }
+
+    @Test
+    fun testOneVoteAllowed() {
+        val ebuilder = ManifestInputBuilder("test_manifest")
+        val election: Manifest = ebuilder.addContest("contest_id")
+            .setVoteVariationType(Manifest.VoteVariationType.one_of_m, 3)
+            .addSelection("selection_id", "candidate_1")
+            .addSelection("selection_id2", "candidate_2")
+            .done()
+            .build()
+        val validator = ManifestInputValidation(election)
+        val problems : ValidationMessages = validator.validate()
+        println("Problems=$problems")
+        assertTrue(problems.hasErrors())
+        assertContains(problems.toString(), "Manifest.C.2")
+    }
+
+    @Test
+    fun testVotesAllowed() {
+        val ebuilder = ManifestInputBuilder("test_manifest")
+        val election: Manifest = ebuilder.addContest("contest_id")
+            .setVoteVariationType(Manifest.VoteVariationType.n_of_m, 3)
+            .addSelection("selection_id", "candidate_1")
+            .addSelection("selection_id2", "candidate_2")
+            .done()
+            .build()
+        val validator = ManifestInputValidation(election)
+        val problems : ValidationMessages = validator.validate()
+        println("Problems=$problems")
+        assertTrue(problems.hasErrors())
+        assertContains(problems.toString(), "Manifest.C.3")
+    }
+
+    @Test
+    fun testVotesApproval() {
+        val ebuilder = ManifestInputBuilder("test_manifest")
+        val election: Manifest = ebuilder.addContest("contest_id")
+            .setVoteVariationType(Manifest.VoteVariationType.approval, 7)
+            .addSelection("selection_id", "candidate_1")
+            .addSelection("selection_id2", "candidate_2")
+            .done()
+            .build()
+        val validator = ManifestInputValidation(election)
+        val problems : ValidationMessages = validator.validate()
+        println("Problems=$problems")
+        assertTrue(problems.hasErrors())
+        assertContains(problems.toString(), "Manifest.C.4")
+    }
+
 }

--- a/src/commonTest/kotlin/electionguard/protoconvert/CommonConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/CommonConvertTest.kt
@@ -10,8 +10,10 @@ class CommonConvertTest {
     @Test
     fun convertElementMod() {
         runTest {
-            checkAll(validElementsModP(productionGroup()), elementsModQ(productionGroup()),)
-                { fakeElementModP, fakeElementModQ ->
+            checkAll(
+                validElementsModP(productionGroup()),
+                elementsModQ(productionGroup()),
+            ) { fakeElementModP, fakeElementModQ ->
                     val context = productionGroup()
 
                     val protoP = fakeElementModP.publishElementModP()
@@ -28,8 +30,10 @@ class CommonConvertTest {
     @Test
     fun convertCiphertext() {
         runTest {
-            checkAll(validElementsModP(productionGroup()), validElementsModP(productionGroup()),)
-                { fakePad, fakeData ->
+            checkAll(
+                validElementsModP(productionGroup()),
+                validElementsModP(productionGroup()),
+            ) { fakePad, fakeData ->
                     val context = productionGroup()
                     val ciphertext = ElGamalCiphertext(fakePad, fakeData)
 
@@ -43,14 +47,17 @@ class CommonConvertTest {
     @Test
     fun convertChaumPedersenProof() {
         runTest {
-            checkAll(elementsModQ(productionGroup()), elementsModQ(productionGroup()),) { c, r ->
-                val context = productionGroup()
-                val proof = GenericChaumPedersenProof(c, r)
+            checkAll(
+                elementsModQ(productionGroup()),
+                elementsModQ(productionGroup()),
+            ) { c, r ->
+                    val context = productionGroup()
+                    val proof = GenericChaumPedersenProof(c, r)
 
-                val proto = proof.publishChaumPedersenProof()
-                val roundtrip = context.importChaumPedersenProof(proto)
-                assertEquals(roundtrip, proof)
-            }
+                    val proto = proof.publishChaumPedersenProof()
+                    val roundtrip = context.importChaumPedersenProof(proto)
+                    assertEquals(roundtrip, proof)
+                }
         }
     }
 
@@ -64,22 +71,10 @@ class CommonConvertTest {
             ) { k, c, r ->
                 val context = productionGroup()
                 val proof = SchnorrProof(k, c, r)
+
                 val proto = proof.publishSchnorrProof()
                 val roundtrip = context.importSchnorrProof(proto)
                 assertEquals(roundtrip, proof)
-            }
-        }
-    }
-
-    @Test
-    fun convertElGamalPublicKey() {
-        runTest {
-            checkAll(validElementsModP(productionGroup()),) { p ->
-                val context = productionGroup()
-                val publicKey = ElGamalPublicKey(p)
-                val proto = publicKey.publishElGamalPublicKey()
-                val roundtrip = context.importElGamalPublicKey(proto)
-                assertEquals(roundtrip, publicKey)
             }
         }
     }

--- a/src/commonTest/kotlin/electionguard/protoconvert/EncryptedBallotConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/EncryptedBallotConvertTest.kt
@@ -74,4 +74,14 @@ class EncryptedBallotConvertTest {
             generateRangeChaumPedersenProofKnownNonce(context),
         )
     }
+
+    @Test
+    fun unknownBallotState() {
+        val context = productionGroup()
+        val ballot = generateEncryptedBallot(42, context).copy(state = EncryptedBallot.BallotState.UNKNOWN)
+        val proto = ballot.publishEncryptedBallot()
+        val roundtrip = context.importEncryptedBallot(proto)
+        assertTrue(roundtrip is Ok)
+        assertEquals(roundtrip.unwrap(), ballot)
+    }
 }

--- a/src/commonTest/kotlin/electionguard/protoconvert/ManifestConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/ManifestConvertTest.kt
@@ -42,14 +42,14 @@ class ManifestConvertTest {
         assertEquals(roundtrip, manifest)
     }
 
-    fun compareAS(list1: List<Manifest.AnnotatedString>?, list2: List<Manifest.AnnotatedString>?) {
+    private fun compareAS(list1: List<Manifest.AnnotatedString>?, list2: List<Manifest.AnnotatedString>?) {
         assertEquals((list1 == null), (list2 == null))
         if ((list1 == null) || (list2 == null)) {
             return
         }
 
         assertEquals(list1.size, list2.size)
-        for (idx in 0 until list1.size) {
+        for (idx in list1.indices) {
             val as1 = list1[idx]
             val as2 = list1[idx]
             assertEquals(as1, as2)
@@ -57,8 +57,8 @@ class ManifestConvertTest {
     }
 
     companion object {
-        val ncontests = 11
-        val nselections = 5
+        private const val ncontests = 11
+        private const val nselections = 5
 
         fun generateFakeManifest(): Manifest {
             //     electionScopeId: String,
@@ -169,7 +169,7 @@ class ManifestConvertTest {
         //        val candidateId: String,
         //        val cryptoHash: ElementModQ
         private fun generateSelection(sseq: Int): Manifest.SelectionDescription {
-            return Manifest.SelectionDescription("selection$sseq", sseq, "candidate$sseq",)
+            return Manifest.SelectionDescription("selection$sseq", sseq, "candidate$sseq")
         }
 
         //         val ballotStyleId: String,
@@ -188,7 +188,7 @@ class ManifestConvertTest {
 
         // val text: List<Language>
         private fun generateInternationalizedText(): Manifest.InternationalizedText {
-            return Manifest.InternationalizedText(List(3) { generateLanguage(it) },)
+            return Manifest.InternationalizedText(List(3) { generateLanguage(it) })
         }
 
         //         val addressLine: List<String>,
@@ -207,12 +207,12 @@ class ManifestConvertTest {
 
         // val value: String, val language: String,
         private fun generateLanguage(seq: Int): Manifest.Language {
-            return Manifest.Language("text$seq", "language:$seq:$seq",)
+            return Manifest.Language("text$seq", "language:$seq:$seq")
         }
 
         // val annotation: String, val value: String,
         private fun generateAnnotatedString(seq: Int): Manifest.AnnotatedString {
-            return Manifest.AnnotatedString("annotate$seq", "value:$seq:$seq",)
+            return Manifest.AnnotatedString("annotate$seq", "value:$seq:$seq")
         }
     }
 }


### PR DESCRIPTION
Remove ManifestInputValidate C.2: "For all contests, votes_allowed == number_elected." 
Finish adding tests for ManifestInputValidate part C. 
See Issue #172