### PR TITLE
Standardize proto conversions.

### DIFF
--- a/docs/CodingConventions.md
+++ b/docs/CodingConventions.md
@@ -1,0 +1,12 @@
+# Coding Conventions
+
+draft 10/28/2022
+
+## Proto Conversions
+
+fun \[GroupContext\].importT( proto: proto.T? or proto.T) : T? or Result<T, String>
+
+fun T.publish() : proto.T
+
+no Exceptions should throw
+do not use object!! without checking for object == null

--- a/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithMasterNonce.kt
+++ b/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithMasterNonce.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.partition
+import com.github.michaelbull.result.unwrap
 import electionguard.ballot.ContestDataStatus
 import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.Manifest
@@ -75,7 +76,12 @@ class DecryptionWithMasterNonce(val group : GroupContext, val manifest: Manifest
         }
 
         // contest data
-        val contestData = contest.contestData.decryptWithNonceToContestData(publicKey, contestDataNonce)
+        val contestDataResult = contest.contestData.decryptWithNonceToContestData(publicKey, contestDataNonce)
+        if (contestDataResult is Err) {
+            return contestDataResult
+        }
+        val contestData = contestDataResult.unwrap()
+
         // on overvote, modify selections to use original votes
         val useSelections = if (contestData.status == ContestDataStatus.over_vote) {
             // set the selections to the original

--- a/src/commonMain/kotlin/electionguard/protoconvert/CommonConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/CommonConvert.kt
@@ -36,43 +36,38 @@ fun GroupContext.importHashedCiphertext(
     if (ciphertext == null) return null
     val c0 = this.importElementModP(ciphertext.c0)
     val c2 = importUInt256(ciphertext.c2)
-    return if (c0 == null || c2 == null) null else HashedElGamalCiphertext(c0, ciphertext.c1.array, c2, ciphertext.numBytes)
+    return if (c0 == null || c2 == null) null else HashedElGamalCiphertext(
+        c0,
+        ciphertext.c1.array,
+        c2,
+        ciphertext.numBytes
+    )
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-fun ElementModQ.publishElementModQ(): electionguard.protogen.ElementModQ {
-    return electionguard.protogen.ElementModQ(ByteArr(this.byteArray()))
-}
+fun ElementModQ.publishElementModQ() = electionguard.protogen.ElementModQ(ByteArr(this.byteArray()))
 
-fun UInt256.publishUInt256(): electionguard.protogen.UInt256 {
-    return electionguard.protogen.UInt256(ByteArr(this.bytes))
-}
+fun UInt256.publishUInt256() = electionguard.protogen.UInt256(ByteArr(this.bytes))
 
-fun ElementModP.publishElementModP(): electionguard.protogen.ElementModP {
-    return electionguard.protogen.ElementModP(ByteArr(this.byteArray()))
-}
+fun ElementModP.publishElementModP() = electionguard.protogen.ElementModP(ByteArr(this.byteArray()))
 
-fun ElGamalCiphertext.publishCiphertext(): electionguard.protogen.ElGamalCiphertext {
-    return electionguard.protogen
-        .ElGamalCiphertext(this.pad.publishElementModP(), this.data.publishElementModP())
-}
+fun ElGamalCiphertext.publishCiphertext() =
+    electionguard.protogen.ElGamalCiphertext(
+        this.pad.publishElementModP(),
+        this.data.publishElementModP(),
+    )
 
-fun GenericChaumPedersenProof.publishChaumPedersenProof():
-    electionguard.protogen.GenericChaumPedersenProof {
-        return electionguard.protogen
-            .GenericChaumPedersenProof(
-                this.c.publishElementModQ(),
-                this.r.publishElementModQ(),
-            )
-    }
+fun GenericChaumPedersenProof.publishChaumPedersenProof() =
+    electionguard.protogen.GenericChaumPedersenProof(
+        this.c.publishElementModQ(),
+        this.r.publishElementModQ(),
+    )
 
-fun HashedElGamalCiphertext.publishHashedCiphertext() :
-    electionguard.protogen.HashedElGamalCiphertext {
-    return electionguard.protogen.HashedElGamalCiphertext(
+fun HashedElGamalCiphertext.publishHashedCiphertext() =
+    electionguard.protogen.HashedElGamalCiphertext(
         this.c0.publishElementModP(),
         ByteArr(this.c1),
         this.c2.publishUInt256(),
         this.numBytes,
     )
-}

--- a/src/commonMain/kotlin/electionguard/protoconvert/DecryptingTrusteeConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/DecryptingTrusteeConvert.kt
@@ -10,11 +10,9 @@ import com.github.michaelbull.result.unwrap
 import electionguard.core.ElGamalKeypair
 import electionguard.core.ElGamalPublicKey
 import electionguard.core.ElGamalSecretKey
-import electionguard.core.ElementModP
 import electionguard.core.GroupContext
 import electionguard.decrypt.DecryptingTrustee
 import electionguard.keyceremony.KeyCeremonyTrustee
-import electionguard.keyceremony.PublicKeys
 import electionguard.keyceremony.SecretKeyShare
 
 // DecryptingTrustee must stay private. DecryptingGuardian is its public info.
@@ -40,52 +38,55 @@ fun GroupContext.importDecryptingTrustee(proto: electionguard.protogen.Decryptin
     return Ok(result)
 }
 
-private fun GroupContext.importElGamalKeypair(id:String, keypair: electionguard.protogen.ElGamalKeypair?):
+private fun GroupContext.importElGamalKeypair(id: String, keypair: electionguard.protogen.ElGamalKeypair?):
         Result<ElGamalKeypair, String> {
     if (keypair == null) {
         return Err("DecryptingTrustee $id missing keypair")
     }
     val secretKey = this.importElementModQ(keypair.secretKey)
-        .toResultOr {"DecryptingTrustee $id secretKey was malformed or missing"}
+        .toResultOr { "DecryptingTrustee $id secretKey was malformed or missing" }
     val publicKey = this.importElementModP(keypair.publicKey)
-        .toResultOr {"DecryptingTrustee $id publicKey was malformed or missing"}
+        .toResultOr { "DecryptingTrustee $id publicKey was malformed or missing" }
 
     val errors = getAllErrors(secretKey, publicKey)
     if (errors.isNotEmpty()) {
         return Err(errors.joinToString("\n"))
     }
-    return Ok(ElGamalKeypair(
-        ElGamalSecretKey(secretKey.unwrap()),
-        ElGamalPublicKey(publicKey.unwrap()),
-    ))
+    return Ok(
+        ElGamalKeypair(
+            ElGamalSecretKey(secretKey.unwrap()),
+            ElGamalPublicKey(publicKey.unwrap()),
+        )
+    )
 }
 
-private fun GroupContext.importSecretKeyShare(id:String, keyShare: electionguard.protogen.SecretKeyShare?):
+private fun GroupContext.importSecretKeyShare(id: String, keyShare: electionguard.protogen.SecretKeyShare?):
         Result<SecretKeyShare, String> {
     if (keyShare == null) {
         return Err("DecryptingTrustee $id missing keypair")
     }
 
     val encryptedCoordinate = this.importHashedCiphertext(keyShare.encryptedCoordinate)
-        .toResultOr {"DecryptingTrustee $id secretKey was malformed or missing"}
+        .toResultOr { "DecryptingTrustee $id secretKey was malformed or missing" }
 
-    val errors = getAllErrors(encryptedCoordinate)
-    if (errors.isNotEmpty()) {
-        return Err(errors.joinToString("\n"))
+    if (encryptedCoordinate is Err) {
+        return encryptedCoordinate
     }
-    return Ok(SecretKeyShare(
-        keyShare.generatingGuardianId,
-        keyShare.designatedGuardianId,
-        keyShare.designatedGuardianXCoordinate,
-        encryptedCoordinate.unwrap(),
-    ))
+    return Ok(
+        SecretKeyShare(
+            keyShare.generatingGuardianId,
+            keyShare.designatedGuardianId,
+            keyShare.designatedGuardianXCoordinate,
+            encryptedCoordinate.unwrap(),
+        )
+    )
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 
-fun KeyCeremonyTrustee.publishDecryptingTrustee(): electionguard.protogen.DecryptingTrustee {
-    return electionguard.protogen.DecryptingTrustee(
+fun KeyCeremonyTrustee.publishDecryptingTrustee() =
+    electionguard.protogen.DecryptingTrustee(
         this.id(),
         this.xCoordinate(),
         ElGamalKeypair(
@@ -94,20 +95,17 @@ fun KeyCeremonyTrustee.publishDecryptingTrustee(): electionguard.protogen.Decryp
         ).publishElGamalKeyPair(),
         this.otherSharesForMe.values.map { it.publishSecretKeyShare() },
     )
-}
 
-private fun ElGamalKeypair.publishElGamalKeyPair(): electionguard.protogen.ElGamalKeypair {
-    return electionguard.protogen.ElGamalKeypair(
+private fun ElGamalKeypair.publishElGamalKeyPair() =
+    electionguard.protogen.ElGamalKeypair(
         this.secretKey.key.publishElementModQ(),
         this.publicKey.key.publishElementModP(),
     )
-}
 
-private fun SecretKeyShare.publishSecretKeyShare(): electionguard.protogen.SecretKeyShare {
-    return electionguard.protogen.SecretKeyShare(
+private fun SecretKeyShare.publishSecretKeyShare() =
+    electionguard.protogen.SecretKeyShare(
         this.generatingGuardianId,
         this.designatedGuardianId,
         this.designatedGuardianXCoordinate,
         this.encryptedCoordinate.publishHashedCiphertext(),
     )
-}

--- a/src/commonMain/kotlin/electionguard/protoconvert/ElectionConfigConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/ElectionConfigConvert.kt
@@ -26,45 +26,42 @@ fun importElectionConfig(config: electionguard.protogen.ElectionConfig?): Result
         manifest.unwrap(),
         config.numberOfGuardians,
         config.quorum,
-        config.metadata.associate {it.key to it.value}
+        config.metadata.associate { it.key to it.value }
     ))
 }
 
-private fun convertConstants(
-    constants: electionguard.protogen.ElectionConstants?
-): Result<ElectionConstants, String> {
+private fun convertConstants(constants: electionguard.protogen.ElectionConstants?): Result<ElectionConstants, String> {
     if (constants == null) {
         return Err("Null Constants")
     }
-    return Ok(ElectionConstants(
-        constants.name,
-        constants.largePrime.array,
-        constants.smallPrime.array,
-        constants.cofactor.array,
-        constants.generator.array,
-    ))
+    return Ok(
+        ElectionConstants(
+            constants.name,
+            constants.largePrime.array,
+            constants.smallPrime.array,
+            constants.cofactor.array,
+            constants.generator.array,
+        )
+    )
 }
 
 ////////////////////////////////////////////////////////
 
-fun ElectionConfig.publishElectionConfig(): electionguard.protogen.ElectionConfig {
-    return electionguard.protogen.ElectionConfig(
+fun ElectionConfig.publishElectionConfig() =
+    electionguard.protogen.ElectionConfig(
         protoVersion,
         constants.publishConstants(),
         manifest.publishManifest(),
         this.numberOfGuardians,
         this.quorum,
-        this.metadata.entries.map { electionguard.protogen.ElectionConfig.MetadataEntry(it.key, it.value)}
+        this.metadata.entries.map { electionguard.protogen.ElectionConfig.MetadataEntry(it.key, it.value) }
     )
-}
 
-private fun ElectionConstants.publishConstants(): electionguard.protogen.ElectionConstants {
-    return electionguard.protogen
-        .ElectionConstants(
-            this.name,
-            ByteArr(this.largePrime),
-            ByteArr(this.smallPrime),
-            ByteArr(this.cofactor),
-            ByteArr(this.generator),
-        )
-}
+private fun ElectionConstants.publishConstants() =
+    electionguard.protogen.ElectionConstants(
+        this.name,
+        ByteArr(this.largePrime),
+        ByteArr(this.smallPrime),
+        ByteArr(this.cofactor),
+        ByteArr(this.generator),
+    )

--- a/src/commonMain/kotlin/electionguard/protoconvert/ElectionResultsConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/ElectionResultsConvert.kt
@@ -9,7 +9,7 @@ import com.github.michaelbull.result.unwrap
 import electionguard.ballot.*
 import electionguard.core.GroupContext
 
-fun GroupContext.importTallyResult(tally : electionguard.protogen.TallyResult?):
+fun GroupContext.importTallyResult(tally: electionguard.protogen.TallyResult?):
         Result<TallyResult, String> {
 
     if (tally == null) {
@@ -29,12 +29,12 @@ fun GroupContext.importTallyResult(tally : electionguard.protogen.TallyResult?):
         encryptedTally.unwrap(),
         tally.ballotIds,
         tally.tallyIds,
-        tally.metadata.associate {it.key to it.value}
+        tally.metadata.associate { it.key to it.value }
     ))
 }
 
-fun GroupContext.importDecryptionResult(decrypt : electionguard.protogen.DecryptionResult):
-        Result<DecryptionResult, String>  {
+fun GroupContext.importDecryptionResult(decrypt: electionguard.protogen.DecryptionResult):
+        Result<DecryptionResult, String> {
     val tallyResult = this.importTallyResult(decrypt.tallyResult)
     val decryptedTally = this.importDecryptedTallyOrBallot(decrypt.decryptedTally)
 
@@ -50,47 +50,46 @@ fun GroupContext.importDecryptionResult(decrypt : electionguard.protogen.Decrypt
         tallyResult.unwrap(),
         decryptedTally.unwrap(),
         guardians,
-        decrypt.metadata.associate {it.key to it.value}
+        decrypt.metadata.associate { it.key to it.value }
     ))
 }
 
 private fun GroupContext.importLagrangeCoefficient(guardian: electionguard.protogen.LagrangeCoordinate):
         Result<LagrangeCoordinate, String> {
     val lagrangeCoefficient = this.importElementModQ(guardian.lagrangeCoefficient)
-        ?: return Err("Failed to translate AvailableGuardian from proto, missing lagrangeCoefficient")
+        ?: return Err("Failed to translate LagrangeCoordinate from proto, missing lagrangeCoefficient")
 
-    return Ok(LagrangeCoordinate(
-        guardian.guardianId,
-        guardian.xCoordinate,
-        lagrangeCoefficient,
-    ))
+    return Ok(
+        LagrangeCoordinate(
+            guardian.guardianId,
+            guardian.xCoordinate,
+            lagrangeCoefficient,
+        )
+    )
 }
 
 ////////////////////////////////////////////////////////
 
-fun TallyResult.publishTallyResult(): electionguard.protogen.TallyResult {
-    return electionguard.protogen.TallyResult(
+fun TallyResult.publishTallyResult() =
+    electionguard.protogen.TallyResult(
         this.electionInitialized.publishElectionInitialized(),
         this.encryptedTally.publishEncryptedTally(),
         this.ballotIds,
         this.tallyIds,
-        this.metadata.entries.map { electionguard.protogen.TallyResult.MetadataEntry(it.key, it.value)}
+        this.metadata.entries.map { electionguard.protogen.TallyResult.MetadataEntry(it.key, it.value) }
     )
-}
 
-fun DecryptionResult.publishDecryptionResult(): electionguard.protogen.DecryptionResult {
-    return electionguard.protogen.DecryptionResult(
+fun DecryptionResult.publishDecryptionResult() =
+    electionguard.protogen.DecryptionResult(
         this.tallyResult.publishTallyResult(),
         this.decryptedTally.publishDecryptedTallyOrBallot(),
-        this.lagrangeCoordinates.map { it.publishAvailableGuardian() },
-        this.metadata.entries.map { electionguard.protogen.DecryptionResult.MetadataEntry(it.key, it.value)}
+        this.lagrangeCoordinates.map { it.publishLagrangeCoordinate() },
+        this.metadata.entries.map { electionguard.protogen.DecryptionResult.MetadataEntry(it.key, it.value) }
     )
-}
 
-private fun LagrangeCoordinate.publishAvailableGuardian(): electionguard.protogen.LagrangeCoordinate {
-    return electionguard.protogen.LagrangeCoordinate(
+private fun LagrangeCoordinate.publishLagrangeCoordinate() =
+    electionguard.protogen.LagrangeCoordinate(
         this.guardianId,
         this.xCoordinate,
         this.lagrangeCoefficient.publishElementModQ(),
     )
-}

--- a/src/commonMain/kotlin/electionguard/protoconvert/EncryptedTallyConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/EncryptedTallyConvert.kt
@@ -15,12 +15,10 @@ fun GroupContext.importEncryptedTally(tally: electionguard.protogen.EncryptedTal
     if (tally == null) {
         return Err("Null EncryptedTally")
     }
-
     val (contests, errors) = tally.contests.map { this.importContest(it) }.partition()
     if (errors.isNotEmpty()) {
         return Err(errors.joinToString("\n"))
     }
-
     return Ok(EncryptedTally(tally.tallyId, contests))
 }
 
@@ -28,60 +26,58 @@ private fun GroupContext.importContest(contest: electionguard.protogen.Encrypted
         Result<EncryptedTally.Contest, String> {
 
     val contestHash = importUInt256(contest.contestDescriptionHash)
-        .toResultOr {"Contest ${contest.contestId} description hash was malformed or missing"}
+        .toResultOr { "Contest ${contest.contestId} description hash was malformed or missing" }
     val (selections, serrors) = contest.selections.map { this.importSelection(it) }.partition()
 
     val errors = getAllErrors(contestHash) + serrors
     if (errors.isNotEmpty()) {
         return Err(errors.joinToString("\n"))
     }
-
     return Ok(EncryptedTally.Contest(contest.contestId, contest.sequenceOrder, contestHash.unwrap(), selections))
 }
 
 private fun GroupContext.importSelection(selection: electionguard.protogen.EncryptedTallySelection):
         Result<EncryptedTally.Selection, String> {
 
-    val selectionDescriptionHash = importUInt256(selection.selectionDescriptionHash)
+    val selectionDescriptionHash =
+        importUInt256(selection.selectionDescriptionHash).toResultOr { "Selection ${selection.selectionId} description hash missing" }
     val ciphertext = this.importCiphertext(selection.ciphertext)
+        .toResultOr { "Selection ${selection.selectionId} ciphertext missing" }
 
-    if (selectionDescriptionHash == null || ciphertext == null) {
-        return Err("Selection ${selection.selectionId} description hash or ciphertext missing")
+    val errors = getAllErrors(selectionDescriptionHash, ciphertext)
+    if (errors.isNotEmpty()) {
+        return Err(errors.joinToString("\n"))
     }
-
-    return Ok(EncryptedTally.Selection(
-        selection.selectionId,
-        selection.sequenceOrder,
-        selectionDescriptionHash,
-        ciphertext
-    ))
+    return Ok(
+        EncryptedTally.Selection(
+            selection.selectionId,
+            selection.sequenceOrder,
+            selectionDescriptionHash.unwrap(),
+            ciphertext.unwrap(),
+        )
+    )
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-fun EncryptedTally.publishEncryptedTally(): electionguard.protogen.EncryptedTally {
-    return electionguard.protogen
-        .EncryptedTally(this.tallyId, this.contests.map { it.publishContest() })
-}
+fun EncryptedTally.publishEncryptedTally() =
+    electionguard.protogen.EncryptedTally(
+        this.tallyId,
+        this.contests.map { it.publishContest() }
+    )
 
-private fun EncryptedTally.Contest.publishContest():
-    electionguard.protogen.EncryptedTallyContest {
-        return electionguard.protogen
-            .EncryptedTallyContest(
-                this.contestId,
-                this.sequenceOrder,
-                this.contestDescriptionHash.publishUInt256(),
-                this.selections.map { it.publishSelection() }
-            )
-    }
+private fun EncryptedTally.Contest.publishContest() =
+    electionguard.protogen.EncryptedTallyContest(
+        this.contestId,
+        this.sequenceOrder,
+        this.contestDescriptionHash.publishUInt256(),
+        this.selections.map { it.publishSelection() }
+    )
 
-private fun EncryptedTally.Selection.publishSelection():
-    electionguard.protogen.EncryptedTallySelection {
-        return electionguard.protogen
-            .EncryptedTallySelection(
-                this.selectionId,
-                this.sequenceOrder,
-                this.selectionDescriptionHash.publishUInt256(),
-                this.ciphertext.publishCiphertext()
-            )
-    }
+private fun EncryptedTally.Selection.publishSelection() =
+    electionguard.protogen.EncryptedTallySelection(
+        this.selectionId,
+        this.sequenceOrder,
+        this.selectionDescriptionHash.publishUInt256(),
+        this.ciphertext.publishCiphertext()
+    )

--- a/src/commonMain/kotlin/electionguard/protoconvert/ManifestFromProto.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/ManifestFromProto.kt
@@ -16,133 +16,124 @@ fun importManifest(manifest: electionguard.protogen.Manifest?):
         return Err("Null Manifest")
     }
 
-    return Ok(Manifest(
-        manifest.electionScopeId,
-        manifest.specVersion,
-        manifest.electionType.importElectionType() ?: Manifest.ElectionType.unknown,
-        manifest.startDate,
-        manifest.endDate,
-        manifest.geopoliticalUnits.map { it.importGeopoliticalUnit() },
-        manifest.parties.map { it.importParty() },
-        manifest.candidates.map { it.importCandidate() },
-        manifest.contests.map { it.importContestDescription() },
-        manifest.ballotStyles.map { it.importBallotStyle() },
-        manifest.name?.let { manifest.name.importInternationalizedText() },
-        manifest.contactInformation?.let { manifest.contactInformation.importContactInformation() },
-    ))
+    return Ok(
+        Manifest(
+            manifest.electionScopeId,
+            manifest.specVersion,
+            importElectionType(manifest.electionType) ?: Manifest.ElectionType.unknown,
+            manifest.startDate,
+            manifest.endDate,
+            manifest.geopoliticalUnits.map { importGeopoliticalUnit(it) },
+            manifest.parties.map { importParty(it) },
+            manifest.candidates.map { importCandidate(it) },
+            manifest.contests.map { importContestDescription(it) },
+            manifest.ballotStyles.map { importBallotStyle(it) },
+            manifest.name?.let { importInternationalizedText(manifest.name) },
+            manifest.contactInformation?.let { importContactInformation(manifest.contactInformation) },
+        )
+    )
 }
 
-private fun electionguard.protogen.AnnotatedString.importAnnotatedString():
+private fun importAnnotatedString(proto: electionguard.protogen.AnnotatedString):
         Manifest.AnnotatedString {
-    return Manifest.AnnotatedString(this.annotation, this.value)
+    return Manifest.AnnotatedString(proto.annotation, proto.value)
 }
 
-private fun electionguard.protogen.BallotStyle.importBallotStyle(): Manifest.BallotStyle {
-    return Manifest.BallotStyle(
-        this.ballotStyleId,
-        this.geopoliticalUnitIds,
-        this.partyIds,
-        this.imageUrl.ifEmpty { null },
+private fun importBallotStyle(proto: electionguard.protogen.BallotStyle) =
+    Manifest.BallotStyle(
+        proto.ballotStyleId,
+        proto.geopoliticalUnitIds,
+        proto.partyIds,
+        proto.imageUrl.ifEmpty { null },
     )
-}
 
-private fun electionguard.protogen.Candidate.importCandidate(): Manifest.Candidate {
-    return Manifest.Candidate(
-        this.candidateId,
-        if (this.name != null) this.name.importInternationalizedText() else internationalizedTextUnknown(),
-        this.partyId.ifEmpty { null },
-        this.imageUrl.ifEmpty { null },
-        this.isWriteIn
+private fun importCandidate(proto: electionguard.protogen.Candidate) =
+    Manifest.Candidate(
+        proto.candidateId,
+        if (proto.name != null) importInternationalizedText(proto.name) else internationalizedTextUnknown(),
+        proto.partyId.ifEmpty { null },
+        proto.imageUrl.ifEmpty { null },
+        proto.isWriteIn
     )
-}
 
-private fun electionguard.protogen.ContactInformation.importContactInformation():
-        Manifest.ContactInformation {
-    return Manifest.ContactInformation(
-        this.addressLine,
-        this.email.map { it.importAnnotatedString() },
-        this.phone.map { it.importAnnotatedString() },
-        this.name.ifEmpty { null },
+private fun importContactInformation(proto: electionguard.protogen.ContactInformation) =
+    Manifest.ContactInformation(
+        proto.addressLine,
+        proto.email.map { importAnnotatedString(it) },
+        proto.phone.map { importAnnotatedString(it) },
+        proto.name.ifEmpty { null },
     )
-}
 
-private fun electionguard.protogen.ContestDescription.importContestDescription():
-        Manifest.ContestDescription {
-    return Manifest.ContestDescription(
-        this.contestId,
-        this.sequenceOrder,
-        this.geopoliticalUnitId,
-        this.voteVariation.importVoteVariationType() ?: Manifest.VoteVariationType.other,
-        this.numberElected,
-        this.votesAllowed,
-        this.name,
-        this.selections.map { it.importSelectionDescription() },
-        this.ballotTitle?.let { this.ballotTitle.importInternationalizedText() },
-        this.ballotSubtitle?.let { this.ballotSubtitle.importInternationalizedText() },
-        this.primaryPartyIds
+private fun importContestDescription(proto: electionguard.protogen.ContestDescription) =
+    Manifest.ContestDescription(
+        proto.contestId,
+        proto.sequenceOrder,
+        proto.geopoliticalUnitId,
+        importVoteVariationType(proto.voteVariation) ?: Manifest.VoteVariationType.other,
+        proto.numberElected,
+        proto.votesAllowed,
+        proto.name,
+        proto.selections.map { importSelectionDescription(it) },
+        proto.ballotTitle?.let { importInternationalizedText(proto.ballotTitle) },
+        proto.ballotSubtitle?.let { importInternationalizedText(proto.ballotSubtitle) },
+        proto.primaryPartyIds
     )
-}
 
-private fun electionguard.protogen.ContestDescription.VoteVariationType.importVoteVariationType():
+private fun importVoteVariationType(proto: electionguard.protogen.ContestDescription.VoteVariationType):
         Manifest.VoteVariationType? {
-    val result = safeEnumValueOf<Manifest.VoteVariationType>(this.name)
+    val result = safeEnumValueOf<Manifest.VoteVariationType>(proto.name)
     if (result == null) {
-        logger.error { "Manifest.VoteVariationType $this has missing or unknown name" }
+        logger.error { "Manifest.VoteVariationType $proto has missing or unknown name" }
     }
     return result
 }
 
-private fun electionguard.protogen.Manifest.ElectionType.importElectionType():
+private fun importElectionType(proto: electionguard.protogen.Manifest.ElectionType):
         Manifest.ElectionType? {
-    val result = safeEnumValueOf<Manifest.ElectionType>(this.name)
+    val result = safeEnumValueOf<Manifest.ElectionType>(proto.name)
     if (result == null) {
-        logger.error { "Manifest.ElectionType $this has missing or unknown name" }
+        logger.error { "Manifest.ElectionType $proto has missing or unknown name" }
     }
     return result
 }
 
-private fun electionguard.protogen.GeopoliticalUnit.ReportingUnitType.importReportingUnitType():
+private fun importReportingUnitType(proto: electionguard.protogen.GeopoliticalUnit.ReportingUnitType):
         Manifest.ReportingUnitType? {
-    val result = safeEnumValueOf<Manifest.ReportingUnitType>(this.name)
+    val result = safeEnumValueOf<Manifest.ReportingUnitType>(proto.name)
     if (result == null) {
-        logger.error { "Manifest.ReportingUnitType $this has missing or unknown name" }
+        logger.error { "Manifest.ReportingUnitType $proto has missing or unknown name" }
     }
     return result
 }
 
-private fun electionguard.protogen.GeopoliticalUnit.importGeopoliticalUnit(): Manifest.GeopoliticalUnit {
-    return Manifest.GeopoliticalUnit(
-        this.geopoliticalUnitId,
-        this.name,
-        this.type.importReportingUnitType() ?: Manifest.ReportingUnitType.unknown,
-        this.contactInformation?.let { this.contactInformation.importContactInformation() },
+private fun importGeopoliticalUnit(proto: electionguard.protogen.GeopoliticalUnit) =
+    Manifest.GeopoliticalUnit(
+        proto.geopoliticalUnitId,
+        proto.name,
+        importReportingUnitType(proto.type) ?: Manifest.ReportingUnitType.unknown,
+        proto.contactInformation?.let { importContactInformation(proto.contactInformation) },
     )
-}
 
-private fun electionguard.protogen.InternationalizedText.importInternationalizedText():
-        Manifest.InternationalizedText {
-    return Manifest.InternationalizedText(this.text.map { it.importLanguage() })
-}
-
-private fun electionguard.protogen.Language.importLanguage(): Manifest.Language {
-    return Manifest.Language(this.value, this.language)
-}
-
-private fun electionguard.protogen.Party.importParty(): Manifest.Party {
-    return Manifest.Party(
-        this.partyId,
-        if (this.name != null) this.name.importInternationalizedText() else internationalizedTextUnknown(),
-        this.abbreviation.ifEmpty { null },
-        this.color.ifEmpty { null },
-        this.logoUri.ifEmpty { null },
+private fun importInternationalizedText(proto: electionguard.protogen.InternationalizedText) =
+    Manifest.InternationalizedText(
+        proto.text.map { importLanguage(it) }
     )
-}
 
-private fun electionguard.protogen.SelectionDescription.importSelectionDescription():
-        Manifest.SelectionDescription {
-    return Manifest.SelectionDescription(
-        this.selectionId,
-        this.sequenceOrder,
-        this.candidateId,
+private fun importLanguage(proto: electionguard.protogen.Language) =
+    Manifest.Language(proto.value, proto.language)
+
+private fun importParty(proto: electionguard.protogen.Party) =
+    Manifest.Party(
+        proto.partyId,
+        if (proto.name != null) importInternationalizedText(proto.name) else internationalizedTextUnknown(),
+        proto.abbreviation.ifEmpty { null },
+        proto.color.ifEmpty { null },
+        proto.logoUri.ifEmpty { null },
     )
-}
+
+private fun importSelectionDescription(proto: electionguard.protogen.SelectionDescription) =
+    Manifest.SelectionDescription(
+        proto.selectionId,
+        proto.sequenceOrder,
+        proto.candidateId,
+    )

--- a/src/commonMain/kotlin/electionguard/protoconvert/ManifestToProto.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/ManifestToProto.kt
@@ -5,9 +5,8 @@ import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger("ManifestToProto")
 
-fun Manifest.publishManifest(): electionguard.protogen.Manifest {
-    return electionguard.protogen
-        .Manifest(
+fun Manifest.publishManifest() =
+    electionguard.protogen.Manifest(
             this.electionScopeId,
             this.specVersion,
             this.electionType.publishElectionType(),
@@ -22,132 +21,103 @@ fun Manifest.publishManifest(): electionguard.protogen.Manifest {
             this.contactInformation?.let { this.contactInformation.publishContactInformation() },
             this.cryptoHash.publishUInt256(),
         )
-}
 
-private fun Manifest.AnnotatedString.publishAnnotatedString():
-    electionguard.protogen.AnnotatedString {
-        return electionguard.protogen.AnnotatedString(this.annotation, this.value)
-    }
+private fun Manifest.AnnotatedString.publishAnnotatedString() =
+    electionguard.protogen.AnnotatedString(this.annotation, this.value)
 
-private fun Manifest.BallotStyle.publishBallotStyle(): electionguard.protogen.BallotStyle {
-    return electionguard.protogen
-        .BallotStyle(
+private fun Manifest.BallotStyle.publishBallotStyle() =
+    electionguard.protogen.BallotStyle(
             this.ballotStyleId,
             this.geopoliticalUnitIds,
             this.partyIds,
             this.imageUri ?: ""
         )
-}
 
-private fun Manifest.Candidate.publishCandidate(): electionguard.protogen.Candidate {
-    return electionguard.protogen
-        .Candidate(
+private fun Manifest.Candidate.publishCandidate() =
+    electionguard.protogen.Candidate(
             this.candidateId,
             this.name.publishInternationalizedText(),
             this.partyId ?: "",
             this.imageUri ?: "",
             this.isWriteIn
         )
-}
 
-private fun Manifest.ContactInformation.publishContactInformation():
-    electionguard.protogen.ContactInformation {
-        return electionguard.protogen
-            .ContactInformation(
-                this.name ?: "",
-                this.addressLine,
-                this.email.map { it.publishAnnotatedString() },
-                this.phone.map { it.publishAnnotatedString() },
-            )
-    }
-
-private fun Manifest.ContestDescription.publishContestDescription():
-    electionguard.protogen.ContestDescription {
-        return electionguard.protogen
-            .ContestDescription(
-                this.contestId,
-                this.sequenceOrder,
-                this.geopoliticalUnitId,
-                this.voteVariation.publishVoteVariationType(),
-                this.numberElected,
-                this.votesAllowed,
-                this.name,
-                this.selections.map { it.publishSelectionDescription() },
-                this.ballotTitle?.let { this.ballotTitle.publishInternationalizedText() },
-                this.ballotSubtitle?.let { this.ballotSubtitle.publishInternationalizedText() },
-                this.primaryPartyIds,
-                this.cryptoHash.publishUInt256(),
-            )
-    }
-
-private fun Manifest.VoteVariationType.publishVoteVariationType():
-    electionguard.protogen.ContestDescription.VoteVariationType {
-        return try {
-            electionguard.protogen.ContestDescription.VoteVariationType.fromName(this.name)
-        } catch (e: IllegalArgumentException) {
-            logger.error { "Manifest.VoteVariationType $this has missing or unknown name" }
-            electionguard.protogen.ContestDescription.VoteVariationType.UNKNOWN
-        }
-    }
-
-private fun Manifest.ElectionType.publishElectionType():
-    electionguard.protogen.Manifest.ElectionType {
-        return try {
-            electionguard.protogen.Manifest.ElectionType.fromName(this.name)
-        } catch (e: IllegalArgumentException) {
-            logger.error { "Manifest.ElectionType $this has missing or unknown name" }
-            electionguard.protogen.Manifest.ElectionType.UNKNOWN
-        }
-    }
-
-private fun Manifest.ReportingUnitType.publishReportingUnitType():
-    electionguard.protogen.GeopoliticalUnit.ReportingUnitType {
-        return try {
-            electionguard.protogen.GeopoliticalUnit.ReportingUnitType.fromName(this.name)
-        } catch (e: IllegalArgumentException) {
-            logger.error { "Manifest.GeopoliticalUnit $this has missing or unknown name" }
-            electionguard.protogen.GeopoliticalUnit.ReportingUnitType.UNKNOWN
-        }
-    }
-
-private fun Manifest.GeopoliticalUnit.publishGeopoliticalUnit():
-    electionguard.protogen.GeopoliticalUnit {
-        return electionguard.protogen
-            .GeopoliticalUnit(
-                this.geopoliticalUnitId,
-                this.name,
-                this.type.publishReportingUnitType(),
-                this.contactInformation?.let { this.contactInformation.publishContactInformation() }
-            )
-    }
-
-private fun Manifest.InternationalizedText.publishInternationalizedText():
-    electionguard.protogen.InternationalizedText {
-        return electionguard.protogen.InternationalizedText(this.text.map { it.publishLanguage() })
-    }
-
-private fun Manifest.Language.publishLanguage(): electionguard.protogen.Language {
-    return electionguard.protogen.Language(this.value, this.language)
-}
-
-private fun Manifest.Party.publishParty(): electionguard.protogen.Party {
-    return electionguard.protogen
-        .Party(
-            this.partyId,
-            this.name.publishInternationalizedText(),
-            this.abbreviation ?: "",
-            this.color ?: "",
-            this.logoUri ?: ""
+private fun Manifest.ContactInformation.publishContactInformation() =
+    electionguard.protogen.ContactInformation(
+            this.name ?: "",
+            this.addressLine,
+            this.email.map { it.publishAnnotatedString() },
+            this.phone.map { it.publishAnnotatedString() },
         )
-}
 
-private fun Manifest.SelectionDescription.publishSelectionDescription():
-    electionguard.protogen.SelectionDescription {
-        return electionguard.protogen
-            .SelectionDescription(
-                this.selectionId,
-                this.sequenceOrder,
-                this.candidateId,
-                this.cryptoHash.publishUInt256(),
-            )
+private fun Manifest.ContestDescription.publishContestDescription() =
+    electionguard.protogen.ContestDescription(
+            this.contestId,
+            this.sequenceOrder,
+            this.geopoliticalUnitId,
+            this.voteVariation.publishVoteVariationType(),
+            this.numberElected,
+            this.votesAllowed,
+            this.name,
+            this.selections.map { it.publishSelectionDescription() },
+            this.ballotTitle?.let { this.ballotTitle.publishInternationalizedText() },
+            this.ballotSubtitle?.let { this.ballotSubtitle.publishInternationalizedText() },
+            this.primaryPartyIds,
+            this.cryptoHash.publishUInt256(),
+        )
+
+
+private fun Manifest.VoteVariationType.publishVoteVariationType() =
+    try {
+        electionguard.protogen.ContestDescription.VoteVariationType.fromName(this.name)
+    } catch (e: IllegalArgumentException) {
+        logger.error { "Manifest.VoteVariationType $this has missing or unknown name" }
+        electionguard.protogen.ContestDescription.VoteVariationType.UNKNOWN
     }
+
+private fun Manifest.ElectionType.publishElectionType() =
+    try {
+        electionguard.protogen.Manifest.ElectionType.fromName(this.name)
+    } catch (e: IllegalArgumentException) {
+        logger.error { "Manifest.ElectionType $this has missing or unknown name" }
+        electionguard.protogen.Manifest.ElectionType.UNKNOWN
+    }
+
+private fun Manifest.ReportingUnitType.publishReportingUnitType() =
+    try {
+        electionguard.protogen.GeopoliticalUnit.ReportingUnitType.fromName(this.name)
+    } catch (e: IllegalArgumentException) {
+        logger.error { "Manifest.GeopoliticalUnit $this has missing or unknown name" }
+        electionguard.protogen.GeopoliticalUnit.ReportingUnitType.UNKNOWN
+    }
+
+private fun Manifest.GeopoliticalUnit.publishGeopoliticalUnit() =
+    electionguard.protogen.GeopoliticalUnit(
+            this.geopoliticalUnitId,
+            this.name,
+            this.type.publishReportingUnitType(),
+            this.contactInformation?.let { this.contactInformation.publishContactInformation() }
+        )
+
+private fun Manifest.InternationalizedText.publishInternationalizedText() =
+    electionguard.protogen.InternationalizedText(this.text.map { it.publishLanguage() })
+
+private fun Manifest.Language.publishLanguage() =
+    electionguard.protogen.Language(this.value, this.language)
+
+private fun Manifest.Party.publishParty() =
+    electionguard.protogen.Party(
+        this.partyId,
+        this.name.publishInternationalizedText(),
+        this.abbreviation ?: "",
+        this.color ?: "",
+        this.logoUri ?: ""
+    )
+
+private fun Manifest.SelectionDescription.publishSelectionDescription() =
+    electionguard.protogen.SelectionDescription(
+            this.selectionId,
+            this.sequenceOrder,
+            this.candidateId,
+            this.cryptoHash.publishUInt256(),
+        )

--- a/src/commonMain/kotlin/electionguard/protoconvert/PlaintextBallotConvert.kt
+++ b/src/commonMain/kotlin/electionguard/protoconvert/PlaintextBallotConvert.kt
@@ -1,64 +1,51 @@
 package electionguard.protoconvert
 
 import electionguard.ballot.PlaintextBallot
-import electionguard.core.GroupContext
 
-fun GroupContext.importPlaintextBallot(ballot: electionguard.protogen.PlaintextBallot): PlaintextBallot {
-    return PlaintextBallot(
+fun importPlaintextBallot(ballot: electionguard.protogen.PlaintextBallot) =
+    PlaintextBallot(
         ballot.ballotId,
         ballot.ballotStyleId,
-        ballot.contests.map { this.importContest(it) },
+        ballot.contests.map { importContest(it) },
         ballot.errors.ifEmpty { null },
     )
-}
 
-private fun GroupContext.importContest(contest: electionguard.protogen.PlaintextBallotContest): PlaintextBallot.Contest {
-    return PlaintextBallot.Contest(
+private fun importContest(contest: electionguard.protogen.PlaintextBallotContest) =
+    PlaintextBallot.Contest(
         contest.contestId,
         contest.sequenceOrder,
         contest.selections.map { importSelection(it) },
         contest.writeIns,
     )
-}
 
-private fun importSelection(selection: electionguard.protogen.PlaintextBallotSelection):
-    PlaintextBallot.Selection {
-        return PlaintextBallot.Selection(
-            selection.selectionId,
-            selection.sequenceOrder,
-            selection.vote,
-        )
-    }
+private fun importSelection(selection: electionguard.protogen.PlaintextBallotSelection) =
+    PlaintextBallot.Selection(
+        selection.selectionId,
+        selection.sequenceOrder,
+        selection.vote,
+    )
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
-fun PlaintextBallot.publishPlaintextBallot(): electionguard.protogen.PlaintextBallot {
-    return electionguard.protogen
-        .PlaintextBallot(
-            this.ballotId,
-            this.ballotStyleId,
-            this.contests.map { it.publishContest() },
-            this.errors?: "",
-            )
-}
+fun PlaintextBallot.publishPlaintextBallot() =
+    electionguard.protogen.PlaintextBallot(
+        this.ballotId,
+        this.ballotStyleId,
+        this.contests.map { it.publishContest() },
+        this.errors ?: "",
+    )
 
-private fun PlaintextBallot.Contest.publishContest():
-    electionguard.protogen.PlaintextBallotContest {
-        return electionguard.protogen
-            .PlaintextBallotContest(
-                this.contestId,
-                this.sequenceOrder,
-                this.selections.map { it.publishSelection() },
-                this.writeIns,
-                )
-    }
+private fun PlaintextBallot.Contest.publishContest() =
+    electionguard.protogen.PlaintextBallotContest(
+            this.contestId,
+            this.sequenceOrder,
+            this.selections.map { it.publishSelection() },
+            this.writeIns,
+        )
 
-private fun PlaintextBallot.Selection.publishSelection():
-    electionguard.protogen.PlaintextBallotSelection {
-        return electionguard.protogen
-            .PlaintextBallotSelection(
-                this.selectionId,
-                this.sequenceOrder,
-                this.vote,
-            )
-    }
+private fun PlaintextBallot.Selection.publishSelection() =
+    electionguard.protogen.PlaintextBallotSelection(
+            this.selectionId,
+            this.sequenceOrder,
+            this.vote,
+        )

--- a/src/commonTest/kotlin/electionguard/ballot/ContestDataEncryptTest.kt
+++ b/src/commonTest/kotlin/electionguard/ballot/ContestDataEncryptTest.kt
@@ -1,5 +1,7 @@
 package electionguard.ballot
 
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.unwrap
 import electionguard.core.decrypt
 import electionguard.core.elGamalKeyPairFromRandom
 import electionguard.core.getSystemTimeInMillis
@@ -15,6 +17,7 @@ import io.kotest.property.checkAll
 import pbandk.decodeFromByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 private const val debug = false
 
@@ -80,14 +83,15 @@ class ContestDataEncryptTest {
 
         // ContestData roundtrip
         val contestDataProtoRoundtrip = electionguard.protogen.ContestData.decodeFromByteArray(contestDataBArt)
-        val contestDataRoundtrip = contestDataProtoRoundtrip.import()
+        val contestDataRoundtrip = importContestData(contestDataProtoRoundtrip)
+        assertTrue( contestDataRoundtrip is Ok)
 
         if (isTruncated) {
             println("truncated $contestData")
             println("          $contestDataRoundtrip")
-            assertEquals(contestData.status, contestDataRoundtrip.status)
+            assertEquals(contestData.status, contestDataRoundtrip.unwrap().status)
         } else {
-            assertEquals(contestData, contestDataRoundtrip)
+            assertEquals(contestData, contestDataRoundtrip.unwrap())
         }
     }
 

--- a/src/commonTest/kotlin/electionguard/protoconvert/PlaintextBallotConvertTest.kt
+++ b/src/commonTest/kotlin/electionguard/protoconvert/PlaintextBallotConvertTest.kt
@@ -1,7 +1,6 @@
 package electionguard.protoconvert
 
 import electionguard.ballot.PlaintextBallot
-import electionguard.core.productionGroup
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -10,10 +9,9 @@ class PlaintextBallotConvertTest {
 
     @Test
     fun roundtripPlaintextBallot() {
-        val group = productionGroup()
         val ballot = generateFakeBallot()
         val proto = ballot.publishPlaintextBallot()
-        val roundtrip = group.importPlaintextBallot(proto)
+        val roundtrip = importPlaintextBallot(proto)
         assertEquals(roundtrip, ballot)
     }
 

--- a/src/commonTest/kotlin/electionguard/workflow/ContestDataTest.kt
+++ b/src/commonTest/kotlin/electionguard/workflow/ContestDataTest.kt
@@ -1,10 +1,12 @@
 package electionguard.workflow
 
+import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.unwrap
 import electionguard.ballot.ContestDataStatus
 import electionguard.ballot.ElectionInitialized
 import electionguard.ballot.Manifest
-import electionguard.ballot.import
+import electionguard.ballot.importContestData
 import electionguard.core.decrypt
 import electionguard.core.elGamalKeyPairFromRandom
 import electionguard.core.productionGroup
@@ -17,6 +19,7 @@ import pbandk.decodeFromByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class ContestDataTest {
     val input = "src/commonTest/data/runWorkflowAllAvailable"
@@ -76,7 +79,10 @@ class ContestDataTest {
 
                 val baRT = it.contestData.decrypt(keypair)!!
                 val protoRoundtrip = electionguard.protogen.ContestData.decodeFromByteArray(baRT)
-                val contestDataRoundtrip = protoRoundtrip.import()
+                val contestDataResult = importContestData(protoRoundtrip)
+                assertTrue( contestDataResult is Ok)
+                val contestDataRoundtrip = contestDataResult.unwrap()
+
                 println("  $contestDataRoundtrip")
                 if (idx == 0) {
                     assertEquals(ContestDataStatus.normal, contestDataRoundtrip.status)

--- a/src/jvmMain/kotlin/electionguard/publish/Consumer.kt
+++ b/src/jvmMain/kotlin/electionguard/publish/Consumer.kt
@@ -104,7 +104,7 @@ actual class Consumer actual constructor(
         if (!Files.exists(Path.of(path.plaintextBallotPath(ballotDir)))) {
             return emptyList()
         }
-        return Iterable { PlaintextBallotIterator(groupContext, path.plaintextBallotPath(ballotDir), filter) }
+        return Iterable { PlaintextBallotIterator(path.plaintextBallotPath(ballotDir), filter) }
     }
 
     // trustee in given directory for given guardianId

--- a/src/jvmMain/kotlin/electionguard/publish/Reader.kt
+++ b/src/jvmMain/kotlin/electionguard/publish/Reader.kt
@@ -75,7 +75,6 @@ fun GroupContext.readDecryptionResult(filename: String): Result<DecryptionResult
 }
 
 class PlaintextBallotIterator(
-    private val group: GroupContext,
     filename: String,
     private val filter: Predicate<PlaintextBallot>?
 ) : AbstractIterator<PlaintextBallot>() {
@@ -90,7 +89,7 @@ class PlaintextBallotIterator(
             }
             val message = input.readNBytes(length)
             val ballotProto = electionguard.protogen.PlaintextBallot.decodeFromByteBuffer(ByteBuffer.wrap(message))
-            val ballot = group.importPlaintextBallot(ballotProto)
+            val ballot = importPlaintextBallot(ballotProto)
             if (filter != null && !filter.test(ballot)) {
                 continue // skip it
             }

--- a/src/nativeMain/kotlin/electionguard/publish/Consumer.kt
+++ b/src/nativeMain/kotlin/electionguard/publish/Consumer.kt
@@ -83,7 +83,7 @@ actual class Consumer actual constructor(
         ballotDir : String,
         filter : ((PlaintextBallot) -> Boolean)?
     ): Iterable<PlaintextBallot> {
-        return Iterable { PlaintextBallotIterator(groupContext, path.plaintextBallotPath(ballotDir), filter) }
+        return Iterable { PlaintextBallotIterator(path.plaintextBallotPath(ballotDir), filter) }
     }
 
     actual fun readTrustee(trusteeDir: String, guardianId: String): DecryptingTrusteeIF {

--- a/src/nativeMain/kotlin/electionguard/publish/Reader.kt
+++ b/src/nativeMain/kotlin/electionguard/publish/Reader.kt
@@ -68,7 +68,6 @@ fun GroupContext.readDecryptionResult(filename: String): Result<DecryptionResult
 }
 
 class PlaintextBallotIterator(
-    private val group: GroupContext,
     private val filename: String,
     val filter : ((PlaintextBallot) -> Boolean)?,
 ) : AbstractIterator<PlaintextBallot>() {
@@ -84,7 +83,7 @@ class PlaintextBallotIterator(
             }
             val message = readFromFile(file, length.toULong(), filename)
             val ballotProto = electionguard.protogen.PlaintextBallot.decodeFromByteArray(message)
-            val ballot = group.importPlaintextBallot(ballotProto)
+            val ballot = importPlaintextBallot(ballotProto)
             if (filter != null && !filter.invoke(ballot)) {
                 continue
             }


### PR DESCRIPTION
Eliminate Exceptions and unchecked null use.
Add logging.
ContestData.decryptXXX returns Result.
PlaintextBallotIterator doesnt need group.
See Issue #172