### PR TITLE
Add Preencryption feature (partially done)

### DIFF
--- a/egklib/src/commonMain/kotlin/electionguard/ballot/EncryptedBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/ballot/EncryptedBallot.kt
@@ -16,6 +16,7 @@ data class EncryptedBallot(
     val timestamp: Long,
     val cryptoHash: UInt256,
     val state: BallotState,
+    val isPreencrypt: Boolean = false,
 ) {
     init {
         require(ballotId.isNotEmpty())
@@ -39,6 +40,8 @@ data class EncryptedBallot(
         val cryptoHash: UInt256,
         val proof: RangeChaumPedersenProofKnownNonce,
         val contestData: HashedElGamalCiphertext,
+        val preEncryption: PreEncryption? = null, // pre-encrypted ballots only
+
     )  : CryptoHashableUInt256 {
         init {
             require(contestId.isNotEmpty())
@@ -46,6 +49,19 @@ data class EncryptedBallot(
         }
         override fun cryptoHashUInt256() = cryptoHash
     }
+
+    data class PreEncryption(
+        val contestHash: UInt256,
+        val selectedVectors: List<PreEncryptionVector> = emptyList(), // size = limit, sorted numerically
+        // The pre-encryption hashes and associated short codes for every option on the ballot – sorted numerically
+        val allHashes: List<PreEncryptionVector> = emptyList(),
+    )
+
+    data class PreEncryptionVector(
+        val selectionHash: UInt256, // H(Vj)
+        val code: String,
+        val selectedVector: List<ElGamalCiphertext>, // Vj, size = nselections, in order by sequenceOrder
+    )
 
     data class Selection(
         val selectionId: String, // matches SelectionDescription.selectionId

--- a/egklib/src/commonMain/kotlin/electionguard/core/ElGamal.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/ElGamal.kt
@@ -219,3 +219,13 @@ fun Iterable<ElGamalCiphertext>.encryptedSum(): ElGamalCiphertext =
             it.ifEmpty { throw ArithmeticException("Cannot sum an empty list of ciphertexts") }
                 .reduce { a, b -> a + b }
         }
+
+/** Add two lists by component-wise multiplication */
+fun List<ElGamalCiphertext>.add(other: List<ElGamalCiphertext>): List<ElGamalCiphertext> {
+    require(this.size == other.size)
+    val result = mutableListOf<ElGamalCiphertext>()
+    this.forEachIndexed { index, value ->
+        result.add(value + other[index])
+    }
+    return result
+}

--- a/egklib/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithPrimaryNonce.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/decryptBallot/DecryptionWithPrimaryNonce.kt
@@ -22,17 +22,17 @@ import electionguard.core.take
 import electionguard.core.toElementModQ
 
 /** Decryption of a EncryptedBallot using the master nonce. */
-class DecryptionWithMasterNonce(val group : GroupContext, val manifest: Manifest, val publicKey: ElGamalPublicKey) {
+class DecryptionWithPrimaryNonce(val group : GroupContext, val manifest: Manifest, val publicKey: ElGamalPublicKey) {
 
-    fun EncryptedBallot.decrypt(masterNonce: ElementModQ): Result<PlaintextBallot, String> {
-        val ballotNonce: UInt256 = hashElements(manifest.cryptoHash, this.ballotId, masterNonce)
+    fun EncryptedBallot.decrypt(primaryNonce: ElementModQ): Result<PlaintextBallot, String> {
+        val ballotNonce: UInt256 = hashElements(manifest.cryptoHash, this.ballotId, primaryNonce)
 
         val (plaintextContests, cerrors) = this.contests.map {
             val mcontest = manifest.contests.find { tcontest -> it.contestId == tcontest.contestId}
             if (mcontest == null) {
                 Err("Cant find contest ${it.contestId} in manifest")
             } else {
-                decryptContestWithMasterNonce(mcontest, ballotNonce, it)
+                decryptContestWithPrimaryNonce(mcontest, ballotNonce, it)
             }
         }.partition()
 
@@ -47,7 +47,7 @@ class DecryptionWithMasterNonce(val group : GroupContext, val manifest: Manifest
         ))
     }
 
-    private fun decryptContestWithMasterNonce(
+    private fun decryptContestWithPrimaryNonce(
         mcontest: Manifest.ContestDescription,
         ballotNonce: UInt256,
         contest: EncryptedBallot.Contest
@@ -64,7 +64,7 @@ class DecryptionWithMasterNonce(val group : GroupContext, val manifest: Manifest
                 errors.add(" Cant find selection ${selection.selectionId} in contest ${mcontest.contestId}")
                 continue
             }
-            val dSelection = decryptSelectionWithMasterNonce(mselection, contestNonce, selection)
+            val dSelection = decryptSelectionWithPrimaryNonce(mselection, contestNonce, selection)
             if (dSelection == null) {
                 errors.add(" decryption with master nonce failed for contest: ${contest.contestId} selection: ${selection.selectionId}")
             } else {
@@ -101,7 +101,7 @@ class DecryptionWithMasterNonce(val group : GroupContext, val manifest: Manifest
         ))
     }
 
-    private fun decryptSelectionWithMasterNonce(
+    private fun decryptSelectionWithPrimaryNonce(
         mselection: Manifest.SelectionDescription,
         contestNonce: ElementModQ,
         selection: EncryptedBallot.Selection

--- a/egklib/src/commonMain/kotlin/electionguard/encrypt/CiphertextBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/encrypt/CiphertextBallot.kt
@@ -13,10 +13,11 @@ data class CiphertextBallot(
     val contests: List<Contest>,
     val timestamp: Long,
     val cryptoHash: UInt256,
-    val masterNonce: ElementModQ,
+    val primaryNonce: ElementModQ,
+    val isPreEncrypt: Boolean = false,
 ) {
     fun ballotNonce(): UInt256 {
-        return hashElements(this.manifestHash, this.ballotId, this.masterNonce)
+        return hashElements(this.manifestHash, this.ballotId, this.primaryNonce)
     }
 
     data class Contest(
@@ -46,6 +47,14 @@ data class CiphertextBallot(
     }
 }
 
+fun CiphertextBallot.cast(): EncryptedBallot {
+    return this.submit(EncryptedBallot.BallotState.CAST)
+}
+
+fun CiphertextBallot.spoil(): EncryptedBallot {
+    return this.submit(EncryptedBallot.BallotState.SPOILED)
+}
+
 fun CiphertextBallot.submit(state: EncryptedBallot.BallotState): EncryptedBallot {
     return EncryptedBallot(
         this.ballotId,
@@ -57,6 +66,7 @@ fun CiphertextBallot.submit(state: EncryptedBallot.BallotState): EncryptedBallot
         this.timestamp,
         this.cryptoHash,
         state,
+        this.isPreEncrypt,
     )
 }
 

--- a/egklib/src/commonMain/kotlin/electionguard/encrypt/ContestPrecompute.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/encrypt/ContestPrecompute.kt
@@ -15,6 +15,7 @@ import electionguard.core.toElementModQ
 import electionguard.core.toUInt256
 
 /**
+ * Experimental.
  * Encrypt Plaintext Ballots into Ciphertext Ballots.
  * A vote triggers the computation of that contest.
  * So most of the work is already done when encrypt() is called,
@@ -29,12 +30,12 @@ class ContestPrecompute(
     val ballotId: String,
     val ballotStyleId: String,
     val codeSeed: ElementModQ,
-    masterNonce: ElementModQ?, // if null, use random
+    primaryNonce: ElementModQ?, // if null, use random
     private val timestampOverride: Long? = null, // if null, use time of encryption
 ) {
     val cryptoExtendedBaseHashQ = cryptoExtendedBaseHash.toElementModQ(group)
-    private val masterNonce: ElementModQ = masterNonce ?: group.randomElementModQ()
-    val ballotNonce: UInt256 = hashElements(manifest.cryptoHashUInt256(), this.ballotId, masterNonce)
+    private val primaryNonce: ElementModQ = primaryNonce ?: group.randomElementModQ()
+    val ballotNonce: UInt256 = hashElements(manifest.cryptoHashUInt256(), this.ballotId, primaryNonce)
     private val mcontests: List<Manifest.ContestDescription>
     val contests: List<Contest>
 
@@ -67,7 +68,7 @@ class ContestPrecompute(
             encryptedContests,
             timestamp,
             cryptoHash,
-            masterNonce,
+            primaryNonce,
         )
     }
 

--- a/egklib/src/commonMain/kotlin/electionguard/encrypt/SelectionPrecompute.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/encrypt/SelectionPrecompute.kt
@@ -15,6 +15,7 @@ import electionguard.core.toElementModQ
 import electionguard.core.toUInt256
 
 /**
+ * Experimental.
  * Encrypt Plaintext Ballots into Ciphertext Ballots.
  * The zero encryptions of all Selections are precomputed.
  * A vote triggers the computation of the one encryption.
@@ -29,12 +30,12 @@ class SelectionPrecompute(
     val ballotId: String,
     val ballotStyleId: String,
     val codeSeed: ElementModQ,
-    masterNonce: ElementModQ?, // if null, use random
+    primaryNonce: ElementModQ?, // if null, use random
     private val timestampOverride: Long? = null, // if null, use time of encryption
 ) {
     val cryptoExtendedBaseHashQ = cryptoExtendedBaseHash.toElementModQ(group)
-    private val masterNonce: ElementModQ = masterNonce ?: group.randomElementModQ()
-    val ballotNonce: UInt256 = hashElements(manifest.cryptoHashUInt256(), this.ballotId, masterNonce)
+    private val primaryNonce: ElementModQ = primaryNonce ?: group.randomElementModQ()
+    val ballotNonce: UInt256 = hashElements(manifest.cryptoHashUInt256(), this.ballotId, primaryNonce)
     private val mcontests: List<Manifest.ContestDescription>
     val contests: List<Contest>
 
@@ -67,7 +68,7 @@ class SelectionPrecompute(
             encryptedContests,
             timestamp,
             cryptoHash,
-            masterNonce,
+            primaryNonce,
         )
     }
 

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/MarkedBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/MarkedBallot.kt
@@ -1,0 +1,23 @@
+package electionguard.preencrypt
+
+/** An internal record representing a cast PreEncryptedBallot, containing the voter choices. */
+internal data class MarkedPreEncryptedBallot(
+    val ballotId: String,
+    val ballotStyleId: String,
+    val contests: List<MarkedPreEncryptedContest>,
+)  {
+    fun show() {
+        println("MarkedPreEncryptedBallot ${ballotId} = ${ballotStyleId}")
+        for (contest in this.contests) {
+            println(" contest ${contest.contestId}")
+            for (selectionCode in contest.selectedCodes) {
+                println("  selection ${selectionCode}")
+            }
+        }
+    }
+}
+
+internal data class MarkedPreEncryptedContest(
+    val contestId: String,
+    val selectedCodes: List<String>, // voter selected "short codes"
+)

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreBallotInternal.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreBallotInternal.kt
@@ -1,0 +1,109 @@
+package electionguard.preencrypt
+
+import electionguard.core.ElGamalCiphertext
+import electionguard.core.UInt256
+import electionguard.core.hashElements
+
+/** An internal record used by PreEncryptor and Recorder. */
+internal data class PreBallotInternal(
+    val ballotId: String,
+    val ballotStyleId: String,
+    val contests: List<PreContestInternal>,
+) {
+    fun show() {
+        println("\nPreBallotInternal $ballotId = $ballotStyleId")
+        for (contest in this.contests) {
+            println(" contest ${contest.contestId}")
+            for (selection in contest.selections) {
+                println("  selection ${selection.selectionId} = ${selection.encrypt0.cryptoHashUInt256()} ${selection.encrypt1.cryptoHashUInt256()}")
+            }
+        }
+    }
+
+    fun makeExternal(
+    ) : PreEncryptedBallot {
+        // the contest hashes are themselves hashed sequentially to form the ballot’s confirmation code.
+        val contestsExternal = this.contests.map { it.makeExternal() }
+        return PreEncryptedBallot(
+            this.ballotId,
+            this.ballotStyleId,
+            contestsExternal, // in order
+            hashElements(contestsExternal.map { it.preencryptionHash }) // sort
+        )
+    }
+}
+
+internal data class PreContestInternal(
+    val contestId: String,
+    val sequenceOrder: Int,
+    val contestCryptoHash: UInt256,
+    val selections: List<PreSelectionInternal>, // must be in sequence order
+    val limit: Int,
+) {
+    fun makeExternal() : PreEncryptedContest {
+        val noneVector = this.selections.map { it.encrypt0 }
+        val noneHashes = (1..limit).map { hashElements(it, noneVector) }
+        val selectionsExternal = this.selections.map { it.makeExternal(this) }
+        val selectionHashes = selectionsExternal.map {it.preencryptionHash}
+
+        // The selection hashes and noneHashes are then sorted numerically and hashed together (in sorted order)
+        // to produce the contest hash.
+        val sortedHashes = (selectionHashes + noneHashes).sortedBy { h -> h.cryptoHashString() }
+
+        return PreEncryptedContest(
+            this.contestId,
+            this.sequenceOrder,
+            selectionsExternal,
+            hashElements(sortedHashes), // contest hash
+        )
+    }
+}
+
+internal data class PreSelectionInternal(
+    val selectionId: String,
+    val sequenceOrder: Int,
+    val selectionCryptoHash: UInt256,
+    val encrypt0: ElGamalCiphertext, // pre-encryption E(0)
+    val encrypt1: ElGamalCiphertext, // pre-encryption E(1)
+    val selectionCode : String? = null // could use hash ?
+) {
+
+    // the selection vector Vj, for example (E1(0), E2(1), E3(0), E4(0)) when j = 2, n = 4
+    fun selectionVector(contest: PreContestInternal): List<ElGamalCiphertext> {
+        return contest.selections.map { if (it == this) it.encrypt1 else it.encrypt0 }
+    }
+
+    // the selection hash H(Vj)
+    fun selectionHash(contest: PreContestInternal): UInt256 {
+        return hashElements(selectionVector(contest))
+    }
+
+    fun makeExternal(contest: PreContestInternal) : PreEncryptedSelection {
+        return PreEncryptedSelection(
+            this.selectionId,
+            this.sequenceOrder,
+            selectionHash(contest), // H(Vj)
+        )
+    }
+}
+
+// we dont know the election code until we create the PreBallotInternal, so now add it
+internal fun PreBallotInternal.addSelectionCodes(preEncrypted : PreEncryptedBallot, codeLen : Int) : PreBallotInternal {
+    val contestsChanged = this.contests.map {
+        val precontest = preEncrypted.contests.find { pre -> pre.contestId == it.contestId}
+            ?: throw IllegalArgumentException("Cant find contest ${it.contestId}")
+        it.addSelectionCodes(precontest, codeLen)
+    }
+    return this.copy(contests = contestsChanged)
+}
+
+internal fun PreContestInternal.addSelectionCodes(preEncrypted : PreEncryptedContest, codeLen : Int) : PreContestInternal {
+    val selectionsChanged = this.selections.map {
+        val presection = preEncrypted.selections.find { pre -> pre.selectionId == it.selectionId}
+            ?: throw IllegalArgumentException("Cant find selection ${it.selectionId}")
+        val match = presection.preencryptionHash.cryptoHashString()
+        val selectionCode = match.substring(match.length - codeLen) // get the lase codeLen chars
+        it.copy(selectionCode = selectionCode)
+    }
+    return this.copy(selections = selectionsChanged)
+}

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptedBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptedBallot.kt
@@ -1,0 +1,37 @@
+package electionguard.preencrypt
+
+import electionguard.core.UInt256
+
+/**
+ * The result of PreEncryptor.preencrypt(), for use by the "Encrypting Tool" to make a pre-encrypted ballot.
+ * One must have the primary nonce in order to generate this.
+ */
+data class PreEncryptedBallot(
+    val ballotId: String,
+    val ballotStyleId: String,
+    val contests: List<PreEncryptedContest>,
+    val confirmationCode: UInt256,
+) {
+    fun show() {
+        println("\nPreEncryptedBallot $ballotId = $ballotStyleId")
+        for (contest in this.contests) {
+            println(" contest ${contest.contestId} = ${contest.preencryptionHash.cryptoHashString()}")
+            for (selection in contest.selections) {
+                println("  selection ${selection.selectionId} = ${selection.preencryptionHash.cryptoHashString()}")
+            }
+        }
+    }
+}
+
+data class PreEncryptedContest(
+    val contestId: String,
+    val sequenceOrder: Int,
+    val selections: List<PreEncryptedSelection>,
+    val preencryptionHash: UInt256, // could compute
+)
+
+data class PreEncryptedSelection(
+    val selectionId: String,
+    val sequenceOrder: Int,
+    val preencryptionHash: UInt256, // H(Vj)
+)

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptor.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/PreEncryptor.kt
@@ -1,0 +1,80 @@
+package electionguard.preencrypt
+
+import electionguard.ballot.Manifest
+import electionguard.core.ElGamalPublicKey
+import electionguard.core.ElementModQ
+import electionguard.core.GroupContext
+import electionguard.core.Nonces
+import electionguard.core.UInt256
+import electionguard.core.encrypt
+import electionguard.core.get
+import electionguard.core.hashElements
+import electionguard.core.toElementModQ
+
+/** The crypto part of the "The Encrypting Tool" */
+class PreEncryptor(
+    val group: GroupContext,
+    val manifest: Manifest,
+    val nonceEncryptionKey: ElGamalPublicKey,
+) {
+    fun preencrypt(
+        ballotId: String,
+        ballotStyleId: String, // matches one in the manifest
+        primaryNonce: UInt256,
+    ): PreEncryptedBallot {
+        return preencryptInternal(ballotId, ballotStyleId, primaryNonce).makeExternal()
+    }
+
+    internal fun preencryptInternal(
+        ballotId: String,
+        ballotStyleId: String,
+        primaryNonce: UInt256,
+    ): PreBallotInternal {
+        val ballotNonce: UInt256 = hashElements(manifest.cryptoHashUInt256(), ballotId, primaryNonce)
+        val mcontests = manifest.styleToContestsMap[ballotStyleId]
+            ?: throw IllegalArgumentException("Unknown ballotStyleId $ballotStyleId")
+
+        val contestsSorted = mcontests.sortedBy { it.sequenceOrder }
+        val contestsInternal = contestsSorted.map { it.preencryptContest(ballotNonce) }
+
+        return PreBallotInternal(
+            ballotId,
+            ballotStyleId,
+            contestsInternal,
+        )
+    }
+
+    private fun Manifest.ContestDescription.preencryptContest(
+        ballotNonce: UInt256,
+    ): PreContestInternal {
+        val contestNonce= Nonces(this.cryptoHash.toElementModQ(group), ballotNonce)[0]
+
+        // for each selection
+        val selectionsSorted = this.selections.sortedWith(compareBy { it.sequenceOrder })
+        val selectionsInternal = selectionsSorted.map {
+            it.preencryptSelection(contestNonce)
+        }
+
+        return PreContestInternal(
+            this.contestId,
+            this.sequenceOrder,
+            this.cryptoHash,
+            selectionsInternal,
+            this.votesAllowed,
+        )
+    }
+
+    private fun Manifest.SelectionDescription.preencryptSelection(
+        contestNonce: ElementModQ,
+    ): PreSelectionInternal {
+        val selectionNonce = Nonces(this.cryptoHash.toElementModQ(group), contestNonce)[1]
+
+        return PreSelectionInternal(
+            this.selectionId,
+            this.sequenceOrder,
+            this.cryptoHash,
+            0.encrypt(nonceEncryptionKey, selectionNonce),
+            1.encrypt(nonceEncryptionKey, selectionNonce),
+        )
+    }
+}

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/RecordedPreBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/RecordedPreBallot.kt
@@ -1,0 +1,77 @@
+package electionguard.preencrypt
+
+import electionguard.core.ElGamalCiphertext
+import electionguard.core.UInt256
+import electionguard.core.hashElements
+
+/**
+ * The result of RecordPreBallot.record(), for use by the "Recording Tool" processing a marked pre-encrypted ballot.
+ * LOOK unfinished
+ */
+data class RecordedPreBallot(
+    val ballotId: String,
+    val contests: List<RecordedPreContest>,
+) {
+    fun show() {
+        println("\nRecordPreBallot $ballotId")
+        for (contest in this.contests) {
+            println(" contest ${contest.contestId} = ${contest.selectedCodes}")
+            println("   preencryptionHash = ${contest.contestHash.cryptoHashString()}")
+            println("   selectionHashes = ${contest.selectionVectors.map {it.selectionHash}}")
+        }
+    }
+}
+
+data class RecordedPreContest(
+    val contestId: String,
+
+    val selectionVectors: List<RecordedSelectionVector> = emptyList(), // sorted by selectionHash
+    val selectedCodes: List<String>, // limit number of them; LOOK are we padding?
+) {
+    val contestHash by lazy { hashElements(selectionVectors.map { it.selectionHash }) }
+}
+
+data class RecordedSelectionVector(
+    val selectionVector: List<ElGamalCiphertext>, // Vj, size = nselections, in order by sequenceOrder
+    val selectionHash: UInt256, // H(Vj)
+) {
+    val code: String = makeCode(selectionHash, 4)
+}
+
+internal fun makeRecordedPreBallot(marked: MarkedPreEncryptedBallot, preInternal: PreBallotInternal): RecordedPreBallot {
+    val contests = mutableListOf<RecordedPreContest>()
+    preInternal.contests.forEach { preContest ->
+        val mcontest = marked.contests.find { it -> it.contestId == preContest.contestId }
+            ?: throw IllegalArgumentException("Cant find ${preContest.contestId}")
+
+        // LOOK all the noneVector are the same. must be wrong.
+        val noneVector = preContest.selections.map { it.encrypt0 }
+        val noneVectors = (1..preContest.limit)
+            .map { RecordedSelectionVector(noneVector, hashElements(it, noneVector)) }
+        val selectionVectors= preContest.selections.map {
+            val sv = it.selectionVector(preContest)
+            RecordedSelectionVector(sv, hashElements(sv))
+        }
+
+        // The selectionVectors and noneVectors are sorted numerically by selectionHash, so cant be associated with a selection
+        val sortedSelectionVectors = (selectionVectors + noneVectors).sortedBy { h -> h.selectionHash.cryptoHashString() }
+
+        contests.add(
+            RecordedPreContest(
+                preContest.contestId,
+                sortedSelectionVectors,
+                mcontest.selectedCodes,
+            )
+        )
+    }
+
+    return RecordedPreBallot(
+        marked.ballotId,
+        contests,
+    )
+}
+
+private fun makeCode(selectionHash: UInt256, codeLen : Int) : String {
+    val match = selectionHash.cryptoHashString()
+    return match.substring(match.length - codeLen) // get the last codeLen chars
+}

--- a/egklib/src/commonMain/kotlin/electionguard/preencrypt/Recorder.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/preencrypt/Recorder.kt
@@ -1,0 +1,90 @@
+package electionguard.preencrypt
+
+import electionguard.ballot.Manifest
+import electionguard.ballot.PlaintextBallot
+import electionguard.core.ElGamalPublicKey
+import electionguard.core.GroupContext
+import electionguard.core.UInt256
+import electionguard.core.toElementModQ
+import electionguard.encrypt.CiphertextBallot
+import electionguard.encrypt.Encryptor
+
+/** The crypto part of the "The Recording Tool" */
+class Recorder(
+    val group: GroupContext,
+    val manifest: Manifest,
+    nonceEncryptionKey: ElGamalPublicKey,
+    cryptoExtendedBaseHash: UInt256,
+) {
+    internal val preEncryptor = PreEncryptor( group, manifest, nonceEncryptionKey)
+    val encryptor = Encryptor( group, manifest, nonceEncryptionKey, cryptoExtendedBaseHash)
+
+    internal fun MarkedPreEncryptedBallot.record(
+        codeSeed : UInt256,
+        primaryNonce: UInt256,
+        codeLen: Int,
+    ): Pair<RecordedPreBallot, CiphertextBallot> {
+        val preInternal = preEncryptor.preencryptInternal(this.ballotId, this.ballotStyleId, primaryNonce)
+        val preEncryptedBallot = preInternal.makeExternal()
+
+        // now find the matches
+        val mballotContests = this.contests.associateBy { it.contestId }
+
+        val plaintextContests = mutableListOf<PlaintextBallot.Contest>()
+        for (pcontest in preEncryptedBallot.contests) {
+            val mcontest = mballotContests[pcontest.contestId]
+            if (mcontest != null) { // ok to skip contests, encryptedBallot will deal
+                plaintextContests.add(mcontest.recordContest(pcontest))
+            }
+        }
+
+        val recordPreBallot = makeRecordedPreBallot(
+            this,
+            preInternal.addSelectionCodes(preEncryptedBallot, codeLen),
+        )
+
+        val plaintextBallot = PlaintextBallot(
+            this.ballotId,
+            this.ballotStyleId,
+            plaintextContests,
+        )
+
+        val ciphertextBallot = encryptor.encrypt(
+            plaintextBallot,
+            codeSeed.toElementModQ(group),
+            primaryNonce.toElementModQ(group),
+            null,
+            preEncryptedBallot.confirmationCode,
+        )
+
+        return Pair(recordPreBallot, ciphertextBallot)
+    }
+
+    private fun MarkedPreEncryptedContest.recordContest(
+        pcontest: PreEncryptedContest,
+    ): PlaintextBallot.Contest {
+
+        val plSelections = mutableListOf<PlaintextBallot.Selection>()
+        for (selectionCode in this.selectedCodes) { // counting on order
+            val plSelection = matchSelection(selectionCode, pcontest) ?:
+                throw IllegalArgumentException("Unknown selectionCode ${selectionCode}")
+            plSelections.add(PlaintextBallot.Selection(
+                plSelection.selectionId,
+                plSelection.sequenceOrder,
+                1,
+            ))
+            println("recordContest ${selectionCode} -> vote for selection ${plSelection.selectionId}")
+        }
+
+        return PlaintextBallot.Contest(
+            pcontest.contestId,
+            pcontest.sequenceOrder,
+            plSelections,
+        )
+    }
+
+    fun matchSelection(selectionCode: String, pcontest: PreEncryptedContest): PreEncryptedSelection? {
+        // just brute search, could make faster
+        return pcontest.selections.find { it.preencryptionHash.cryptoHashString().endsWith(selectionCode) }
+    }
+}

--- a/egklib/src/commonMain/kotlin/electionguard/protogen/common.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/protogen/common.kt
@@ -325,6 +325,64 @@ public data class HashedElGamalCiphertext(
 }
 
 @pbandk.Export
+public data class SchnorrProof(
+    val publicKey: electionguard.protogen.ElementModP? = null,
+    val challenge: electionguard.protogen.ElementModQ? = null,
+    val response: electionguard.protogen.ElementModQ? = null,
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.SchnorrProof = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.SchnorrProof> get() = Companion.descriptor
+    override val protoSize: Int by lazy { super.protoSize }
+    public companion object : pbandk.Message.Companion<electionguard.protogen.SchnorrProof> {
+        public val defaultInstance: electionguard.protogen.SchnorrProof by lazy { electionguard.protogen.SchnorrProof() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.SchnorrProof = electionguard.protogen.SchnorrProof.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.SchnorrProof> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.SchnorrProof, *>>(3)
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "public_key",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModP.Companion),
+                        jsonName = "publicKey",
+                        value = electionguard.protogen.SchnorrProof::publicKey
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "challenge",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
+                        jsonName = "challenge",
+                        value = electionguard.protogen.SchnorrProof::challenge
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "response",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
+                        jsonName = "response",
+                        value = electionguard.protogen.SchnorrProof::response
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                fullName = "SchnorrProof",
+                messageClass = electionguard.protogen.SchnorrProof::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+@pbandk.Export
 public data class UInt256(
     val value: pbandk.ByteArr = pbandk.ByteArr.empty,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -514,6 +572,35 @@ private fun HashedElGamalCiphertext.Companion.decodeWithImpl(u: pbandk.MessageDe
         }
     }
     return HashedElGamalCiphertext(c0, c1, c2, numBytes, unknownFields)
+}
+
+@pbandk.Export
+@pbandk.JsName("orDefaultForSchnorrProof")
+public fun SchnorrProof?.orDefault(): electionguard.protogen.SchnorrProof = this ?: SchnorrProof.defaultInstance
+
+private fun SchnorrProof.protoMergeImpl(plus: pbandk.Message?): SchnorrProof = (plus as? SchnorrProof)?.let {
+    it.copy(
+        publicKey = publicKey?.plus(plus.publicKey) ?: plus.publicKey,
+        challenge = challenge?.plus(plus.challenge) ?: plus.challenge,
+        response = response?.plus(plus.response) ?: plus.response,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun SchnorrProof.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SchnorrProof {
+    var publicKey: electionguard.protogen.ElementModP? = null
+    var challenge: electionguard.protogen.ElementModQ? = null
+    var response: electionguard.protogen.ElementModQ? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> publicKey = _fieldValue as electionguard.protogen.ElementModP
+            2 -> challenge = _fieldValue as electionguard.protogen.ElementModQ
+            3 -> response = _fieldValue as electionguard.protogen.ElementModQ
+        }
+    }
+    return SchnorrProof(publicKey, challenge, response, unknownFields)
 }
 
 @pbandk.Export

--- a/egklib/src/commonMain/kotlin/electionguard/protogen/election_record.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/protogen/election_record.kt
@@ -426,64 +426,6 @@ public data class Guardian(
 }
 
 @pbandk.Export
-public data class SchnorrProof(
-    val publicKey: electionguard.protogen.ElementModP? = null,
-    val challenge: electionguard.protogen.ElementModQ? = null,
-    val response: electionguard.protogen.ElementModQ? = null,
-    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
-) : pbandk.Message {
-    override operator fun plus(other: pbandk.Message?): electionguard.protogen.SchnorrProof = protoMergeImpl(other)
-    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.SchnorrProof> get() = Companion.descriptor
-    override val protoSize: Int by lazy { super.protoSize }
-    public companion object : pbandk.Message.Companion<electionguard.protogen.SchnorrProof> {
-        public val defaultInstance: electionguard.protogen.SchnorrProof by lazy { electionguard.protogen.SchnorrProof() }
-        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.SchnorrProof = electionguard.protogen.SchnorrProof.decodeWithImpl(u)
-
-        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.SchnorrProof> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.SchnorrProof, *>>(3)
-            fieldsList.apply {
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "public_key",
-                        number = 1,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModP.Companion),
-                        jsonName = "publicKey",
-                        value = electionguard.protogen.SchnorrProof::publicKey
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "challenge",
-                        number = 2,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
-                        jsonName = "challenge",
-                        value = electionguard.protogen.SchnorrProof::challenge
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "response",
-                        number = 3,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElementModQ.Companion),
-                        jsonName = "response",
-                        value = electionguard.protogen.SchnorrProof::response
-                    )
-                )
-            }
-            pbandk.MessageDescriptor(
-                fullName = "SchnorrProof",
-                messageClass = electionguard.protogen.SchnorrProof::class,
-                messageCompanion = this,
-                fields = fieldsList
-            )
-        }
-    }
-}
-
-@pbandk.Export
 public data class TallyResult(
     val electionInit: electionguard.protogen.ElectionInitialized? = null,
     val encryptedTally: electionguard.protogen.EncryptedTally? = null,
@@ -964,35 +906,6 @@ private fun Guardian.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Guardia
         }
     }
     return Guardian(guardianId, xCoordinate, pbandk.ListWithSize.Builder.fixed(coefficientProofs), unknownFields)
-}
-
-@pbandk.Export
-@pbandk.JsName("orDefaultForSchnorrProof")
-public fun SchnorrProof?.orDefault(): electionguard.protogen.SchnorrProof = this ?: SchnorrProof.defaultInstance
-
-private fun SchnorrProof.protoMergeImpl(plus: pbandk.Message?): SchnorrProof = (plus as? SchnorrProof)?.let {
-    it.copy(
-        publicKey = publicKey?.plus(plus.publicKey) ?: plus.publicKey,
-        challenge = challenge?.plus(plus.challenge) ?: plus.challenge,
-        response = response?.plus(plus.response) ?: plus.response,
-        unknownFields = unknownFields + plus.unknownFields
-    )
-} ?: this
-
-@Suppress("UNCHECKED_CAST")
-private fun SchnorrProof.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SchnorrProof {
-    var publicKey: electionguard.protogen.ElementModP? = null
-    var challenge: electionguard.protogen.ElementModQ? = null
-    var response: electionguard.protogen.ElementModQ? = null
-
-    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
-        when (_fieldNumber) {
-            1 -> publicKey = _fieldValue as electionguard.protogen.ElementModP
-            2 -> challenge = _fieldValue as electionguard.protogen.ElementModQ
-            3 -> response = _fieldValue as electionguard.protogen.ElementModQ
-        }
-    }
-    return SchnorrProof(publicKey, challenge, response, unknownFields)
 }
 
 @pbandk.Export

--- a/egklib/src/commonMain/kotlin/electionguard/protogen/encrypted_ballot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/protogen/encrypted_ballot.kt
@@ -13,6 +13,7 @@ public data class EncryptedBallot(
     val timestamp: Long = 0L,
     val cryptoHash: electionguard.protogen.UInt256? = null,
     val state: electionguard.protogen.EncryptedBallot.BallotState = electionguard.protogen.EncryptedBallot.BallotState.fromValue(0),
+    val isPreencrypt: Boolean = false,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): electionguard.protogen.EncryptedBallot = protoMergeImpl(other)
@@ -23,7 +24,7 @@ public data class EncryptedBallot(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.EncryptedBallot = electionguard.protogen.EncryptedBallot.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.EncryptedBallot> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallot, *>>(9)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallot, *>>(10)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -115,6 +116,16 @@ public data class EncryptedBallot(
                         value = electionguard.protogen.EncryptedBallot::state
                     )
                 )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "is_preencrypt",
+                        number = 10,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(),
+                        jsonName = "isPreencrypt",
+                        value = electionguard.protogen.EncryptedBallot::isPreencrypt
+                    )
+                )
             }
             pbandk.MessageDescriptor(
                 fullName = "EncryptedBallot",
@@ -152,6 +163,7 @@ public data class EncryptedBallotContest(
     val cryptoHash: electionguard.protogen.UInt256? = null,
     val proof: electionguard.protogen.RangeChaumPedersenProofKnownNonce? = null,
     val encryptedContestData: electionguard.protogen.HashedElGamalCiphertext? = null,
+    val preEncryption: electionguard.protogen.PreEncryption? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): electionguard.protogen.EncryptedBallotContest = protoMergeImpl(other)
@@ -162,7 +174,7 @@ public data class EncryptedBallotContest(
         override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.EncryptedBallotContest = electionguard.protogen.EncryptedBallotContest.decodeWithImpl(u)
 
         override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.EncryptedBallotContest> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallotContest, *>>(7)
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.EncryptedBallotContest, *>>(8)
             fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
@@ -234,10 +246,136 @@ public data class EncryptedBallotContest(
                         value = electionguard.protogen.EncryptedBallotContest::encryptedContestData
                     )
                 )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "pre_encryption",
+                        number = 8,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PreEncryption.Companion),
+                        jsonName = "preEncryption",
+                        value = electionguard.protogen.EncryptedBallotContest::preEncryption
+                    )
+                )
             }
             pbandk.MessageDescriptor(
                 fullName = "EncryptedBallotContest",
                 messageClass = electionguard.protogen.EncryptedBallotContest::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+@pbandk.Export
+public data class PreEncryption(
+    val contestHash: electionguard.protogen.UInt256? = null,
+    val selectedVectors: List<electionguard.protogen.PreEncryptionVector> = emptyList(),
+    val allHashes: List<electionguard.protogen.PreEncryptionVector> = emptyList(),
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.PreEncryption = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PreEncryption> get() = Companion.descriptor
+    override val protoSize: Int by lazy { super.protoSize }
+    public companion object : pbandk.Message.Companion<electionguard.protogen.PreEncryption> {
+        public val defaultInstance: electionguard.protogen.PreEncryption by lazy { electionguard.protogen.PreEncryption() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.PreEncryption = electionguard.protogen.PreEncryption.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PreEncryption> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PreEncryption, *>>(3)
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "contest_hash",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.UInt256.Companion),
+                        jsonName = "contestHash",
+                        value = electionguard.protogen.PreEncryption::contestHash
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "selected_vectors",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.PreEncryptionVector>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PreEncryptionVector.Companion)),
+                        jsonName = "selectedVectors",
+                        value = electionguard.protogen.PreEncryption::selectedVectors
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "all_hashes",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.PreEncryptionVector>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.PreEncryptionVector.Companion)),
+                        jsonName = "allHashes",
+                        value = electionguard.protogen.PreEncryption::allHashes
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                fullName = "PreEncryption",
+                messageClass = electionguard.protogen.PreEncryption::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+@pbandk.Export
+public data class PreEncryptionVector(
+    val selectionHash: electionguard.protogen.UInt256? = null,
+    val code: String = "",
+    val selectedVector: List<electionguard.protogen.ElGamalCiphertext> = emptyList(),
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?): electionguard.protogen.PreEncryptionVector = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PreEncryptionVector> get() = Companion.descriptor
+    override val protoSize: Int by lazy { super.protoSize }
+    public companion object : pbandk.Message.Companion<electionguard.protogen.PreEncryptionVector> {
+        public val defaultInstance: electionguard.protogen.PreEncryptionVector by lazy { electionguard.protogen.PreEncryptionVector() }
+        override fun decodeWith(u: pbandk.MessageDecoder): electionguard.protogen.PreEncryptionVector = electionguard.protogen.PreEncryptionVector.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<electionguard.protogen.PreEncryptionVector> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<electionguard.protogen.PreEncryptionVector, *>>(3)
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "selection_hash",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.UInt256.Companion),
+                        jsonName = "selectionHash",
+                        value = electionguard.protogen.PreEncryptionVector::selectionHash
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "code",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "code",
+                        value = electionguard.protogen.PreEncryptionVector::code
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "selected_vector",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Repeated<electionguard.protogen.ElGamalCiphertext>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = electionguard.protogen.ElGamalCiphertext.Companion)),
+                        jsonName = "selectedVector",
+                        value = electionguard.protogen.PreEncryptionVector::selectedVector
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                fullName = "PreEncryptionVector",
+                messageClass = electionguard.protogen.PreEncryptionVector::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -398,6 +536,7 @@ private fun EncryptedBallot.Companion.decodeWithImpl(u: pbandk.MessageDecoder): 
     var timestamp = 0L
     var cryptoHash: electionguard.protogen.UInt256? = null
     var state: electionguard.protogen.EncryptedBallot.BallotState = electionguard.protogen.EncryptedBallot.BallotState.fromValue(0)
+    var isPreencrypt = false
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
@@ -410,11 +549,12 @@ private fun EncryptedBallot.Companion.decodeWithImpl(u: pbandk.MessageDecoder): 
             7 -> timestamp = _fieldValue as Long
             8 -> cryptoHash = _fieldValue as electionguard.protogen.UInt256
             9 -> state = _fieldValue as electionguard.protogen.EncryptedBallot.BallotState
+            10 -> isPreencrypt = _fieldValue as Boolean
         }
     }
     return EncryptedBallot(ballotId, ballotStyleId, manifestHash, codeSeed,
         code, pbandk.ListWithSize.Builder.fixed(contests), timestamp, cryptoHash,
-        state, unknownFields)
+        state, isPreencrypt, unknownFields)
 }
 
 @pbandk.Export
@@ -428,6 +568,7 @@ private fun EncryptedBallotContest.protoMergeImpl(plus: pbandk.Message?): Encryp
         cryptoHash = cryptoHash?.plus(plus.cryptoHash) ?: plus.cryptoHash,
         proof = proof?.plus(plus.proof) ?: plus.proof,
         encryptedContestData = encryptedContestData?.plus(plus.encryptedContestData) ?: plus.encryptedContestData,
+        preEncryption = preEncryption?.plus(plus.preEncryption) ?: plus.preEncryption,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -441,6 +582,7 @@ private fun EncryptedBallotContest.Companion.decodeWithImpl(u: pbandk.MessageDec
     var cryptoHash: electionguard.protogen.UInt256? = null
     var proof: electionguard.protogen.RangeChaumPedersenProofKnownNonce? = null
     var encryptedContestData: electionguard.protogen.HashedElGamalCiphertext? = null
+    var preEncryption: electionguard.protogen.PreEncryption? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
@@ -451,10 +593,68 @@ private fun EncryptedBallotContest.Companion.decodeWithImpl(u: pbandk.MessageDec
             5 -> cryptoHash = _fieldValue as electionguard.protogen.UInt256
             6 -> proof = _fieldValue as electionguard.protogen.RangeChaumPedersenProofKnownNonce
             7 -> encryptedContestData = _fieldValue as electionguard.protogen.HashedElGamalCiphertext
+            8 -> preEncryption = _fieldValue as electionguard.protogen.PreEncryption
         }
     }
     return EncryptedBallotContest(contestId, sequenceOrder, contestHash, pbandk.ListWithSize.Builder.fixed(selections),
-        cryptoHash, proof, encryptedContestData, unknownFields)
+        cryptoHash, proof, encryptedContestData, preEncryption, unknownFields)
+}
+
+@pbandk.Export
+@pbandk.JsName("orDefaultForPreEncryption")
+public fun PreEncryption?.orDefault(): electionguard.protogen.PreEncryption = this ?: PreEncryption.defaultInstance
+
+private fun PreEncryption.protoMergeImpl(plus: pbandk.Message?): PreEncryption = (plus as? PreEncryption)?.let {
+    it.copy(
+        contestHash = contestHash?.plus(plus.contestHash) ?: plus.contestHash,
+        selectedVectors = selectedVectors + plus.selectedVectors,
+        allHashes = allHashes + plus.allHashes,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun PreEncryption.Companion.decodeWithImpl(u: pbandk.MessageDecoder): PreEncryption {
+    var contestHash: electionguard.protogen.UInt256? = null
+    var selectedVectors: pbandk.ListWithSize.Builder<electionguard.protogen.PreEncryptionVector>? = null
+    var allHashes: pbandk.ListWithSize.Builder<electionguard.protogen.PreEncryptionVector>? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> contestHash = _fieldValue as electionguard.protogen.UInt256
+            2 -> selectedVectors = (selectedVectors ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.PreEncryptionVector> }
+            3 -> allHashes = (allHashes ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.PreEncryptionVector> }
+        }
+    }
+    return PreEncryption(contestHash, pbandk.ListWithSize.Builder.fixed(selectedVectors), pbandk.ListWithSize.Builder.fixed(allHashes), unknownFields)
+}
+
+@pbandk.Export
+@pbandk.JsName("orDefaultForPreEncryptionVector")
+public fun PreEncryptionVector?.orDefault(): electionguard.protogen.PreEncryptionVector = this ?: PreEncryptionVector.defaultInstance
+
+private fun PreEncryptionVector.protoMergeImpl(plus: pbandk.Message?): PreEncryptionVector = (plus as? PreEncryptionVector)?.let {
+    it.copy(
+        selectionHash = selectionHash?.plus(plus.selectionHash) ?: plus.selectionHash,
+        selectedVector = selectedVector + plus.selectedVector,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun PreEncryptionVector.Companion.decodeWithImpl(u: pbandk.MessageDecoder): PreEncryptionVector {
+    var selectionHash: electionguard.protogen.UInt256? = null
+    var code = ""
+    var selectedVector: pbandk.ListWithSize.Builder<electionguard.protogen.ElGamalCiphertext>? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> selectionHash = _fieldValue as electionguard.protogen.UInt256
+            2 -> code = _fieldValue as String
+            3 -> selectedVector = (selectedVector ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<electionguard.protogen.ElGamalCiphertext> }
+        }
+    }
+    return PreEncryptionVector(selectionHash, code, pbandk.ListWithSize.Builder.fixed(selectedVector), unknownFields)
 }
 
 @pbandk.Export

--- a/egklib/src/commonMain/proto/encrypted_ballot.proto
+++ b/egklib/src/commonMain/proto/encrypted_ballot.proto
@@ -15,13 +15,14 @@ message EncryptedBallot {
 
   string ballot_id = 1; // a unique Ballot ID created by the external system
   string ballot_style_id = 2; // The ballot_style_id of the BallotStyle in the Election Manifest
-  UInt256 manifest_hash = 3; // Matches Manifest.crypto_hash
+  UInt256 manifest_hash = 3; // Matches Manifest.crypto_hash LOOK check this when processing
   UInt256 code_seed = 4; // Previous ballot tracking hash or seed hash, aka code_seed
   UInt256 code = 5; // ballot tracking code, H_i
   repeated EncryptedBallotContest contests = 6;
   int64 timestamp = 7; // Timestamp at which the ballot encryption is generated, in seconds since the epoch UTC.
   UInt256 crypto_hash = 8;
   BallotState state = 9;
+  bool is_preencrypt = 10;
 }
 
 // Encrypted selections for a specific contest.
@@ -33,6 +34,21 @@ message EncryptedBallotContest {
   UInt256 crypto_hash = 5;
   RangeChaumPedersenProofKnownNonce proof = 6;  // The proof the sum of the selections does not exceed the maximum
   HashedElGamalCiphertext encrypted_contest_data = 7; // see 3.3.4
+  PreEncryption pre_encryption = 8; // only for pre-encryptions
+}
+
+message PreEncryption {
+  UInt256 contest_hash = 1;
+  repeated PreEncryptionVector selected_vectors = 2; // size = limit – sorted numerically
+  // The pre-encryption hashes and associated short codes for every option on the ballot – sorted numerically
+  repeated PreEncryptionVector all_hashes = 3;
+}
+
+message PreEncryptionVector {
+  UInt256 selection_hash = 1; // H(Vj)
+  string code = 2;
+  // present only for selected_vectors
+  repeated ElGamalCiphertext selected_vector = 3; // Vj, size = nselections, in order by sequence_order
 }
 
 // Encryption of a specific selection.

--- a/egklib/src/commonTest/kotlin/electionguard/decryptBallot/DecryptionWithNonceTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decryptBallot/DecryptionWithNonceTest.kt
@@ -43,8 +43,8 @@ class DecryptionWithNonceTest {
         RandomBallotProvider(electionInit.manifest(), nballots).ballots().forEach { ballot ->
             val startEncrypt = getSystemTimeInMillis()
             val codeSeed = group.randomElementModQ(minimum = 2)
-            val masterNonce = group.randomElementModQ(minimum = 2)
-            val encryptedBallot = encryptor.encrypt(ballot, codeSeed, masterNonce, 0)
+            val primaryNonce = group.randomElementModQ(minimum = 2)
+            val encryptedBallot = encryptor.encrypt(ballot, codeSeed, primaryNonce, 0)
             encryptTime += getSystemTimeInMillis() - startEncrypt
 
             // decrypt with nonces and check
@@ -89,9 +89,9 @@ class DecryptionWithNonceTest {
         println("testDecryptionWithEmbeddedNonces for $nballots ballots took $encryptPerBallot encrypt, $decryptPerBallot decrypt msecs/ballot")
     }
 
-    /** test DecryptionWithMasterNonce: encrypt ballot, decrypt with master nonce, check match. */
+    /** test DecryptionWithPrimaryNonce: encrypt ballot, decrypt with master nonce, check match. */
     @Test
-    fun testDecryptionWithMasterNonce() {
+    fun testDecryptionWithPrimaryNonce() {
         val group = productionGroup()
         val consumerIn = Consumer(input, group)
         val electionInit: ElectionInitialized =
@@ -108,16 +108,16 @@ class DecryptionWithNonceTest {
         RandomBallotProvider(electionInit.manifest(), nballots).ballots().forEach { ballot ->
             val startEncrypt = getSystemTimeInMillis()
             val codeSeed = group.randomElementModQ(minimum = 2)
-            val masterNonce = group.randomElementModQ(minimum = 2)
-            val ciphertextBallot = encryptor.encrypt(ballot, codeSeed, masterNonce, 0)
+            val primaryNonce = group.randomElementModQ(minimum = 2)
+            val ciphertextBallot = encryptor.encrypt(ballot, codeSeed, primaryNonce, 0)
             val encryptedBallot = ciphertextBallot.submit(EncryptedBallot.BallotState.CAST)
             encryptTime += getSystemTimeInMillis() - startEncrypt
 
             // decrypt with master nonce
             val startDecrypt = getSystemTimeInMillis()
-            val decryptionWithMasterNonce = DecryptionWithMasterNonce(group, electionInit.manifest(), electionInit.jointPublicKey())
-            val decryptedBallotResult = with (decryptionWithMasterNonce) { encryptedBallot.decrypt(masterNonce) }
-            assertFalse(decryptedBallotResult is Err, "decryptionWithMasterNonce failed on ballot ${ballot.ballotId} errors = $decryptedBallotResult")
+            val decryptionWithPrimaryNonce = DecryptionWithPrimaryNonce(group, electionInit.manifest(), electionInit.jointPublicKey())
+            val decryptedBallotResult = with (decryptionWithPrimaryNonce) { encryptedBallot.decrypt(primaryNonce) }
+            assertFalse(decryptedBallotResult is Err, "decryptionWithPrimaryNonce failed on ballot ${ballot.ballotId} errors = $decryptedBallotResult")
             val decryptedBallot = decryptedBallotResult.unwrap()
 
             // all non zero votes match
@@ -152,10 +152,10 @@ class DecryptionWithNonceTest {
 
         val encryptPerBallot = (encryptTime.toDouble() / nballots).roundToInt()
         val decryptPerBallot = (decryptTime.toDouble() / nballots).roundToInt()
-        println("testDecryptionWithMasterNonce for $nballots ballots took $encryptPerBallot encrypt, $decryptPerBallot decrypt msecs/ballot")
+        println("testDecryptionWithPrimaryNonce for $nballots ballots took $encryptPerBallot encrypt, $decryptPerBallot decrypt msecs/ballot")
     }
 
-    /** test DecryptionWithMasterNonce: encrypt ballot, decrypt with master nonce, check match. */
+    /** test DecryptionWithPrimaryNonce: encrypt ballot, decrypt with master nonce, check match. */
     @Test
     fun testDecryptionOfContestData() {
         val group = productionGroup()
@@ -174,17 +174,17 @@ class DecryptionWithNonceTest {
         val nb = 100
         RandomBallotProvider(electionInit.manifest(), nb, true).ballots().forEach { ballot ->
             val codeSeed = group.randomElementModQ(minimum = 2)
-            val masterNonce = group.randomElementModQ(minimum = 2)
+            val primaryNonce = group.randomElementModQ(minimum = 2)
             val startEncrypt = getSystemTimeInMillis()
-            val ciphertextBallot = encryptor.encrypt(ballot, codeSeed, masterNonce, 0)
+            val ciphertextBallot = encryptor.encrypt(ballot, codeSeed, primaryNonce, 0)
             val encryptedBallot = ciphertextBallot.submit(EncryptedBallot.BallotState.CAST)
             encryptTime += getSystemTimeInMillis() - startEncrypt
 
             // decrypt with master nonce
             val startDecrypt = getSystemTimeInMillis()
-            val decryptionWithMasterNonce = DecryptionWithMasterNonce(group, electionInit.manifest(), electionInit.jointPublicKey())
-            val decryptedBallotResult = with (decryptionWithMasterNonce) { encryptedBallot.decrypt(masterNonce) }
-            assertFalse(decryptedBallotResult is Err, "decryptionWithMasterNonce failed on ballot ${ballot.ballotId} errors = $decryptedBallotResult")
+            val decryptionWithPrimaryNonce = DecryptionWithPrimaryNonce(group, electionInit.manifest(), electionInit.jointPublicKey())
+            val decryptedBallotResult = with (decryptionWithPrimaryNonce) { encryptedBallot.decrypt(primaryNonce) }
+            assertFalse(decryptedBallotResult is Err, "decryptionWithPrimaryNonce failed on ballot ${ballot.ballotId} errors = $decryptedBallotResult")
             val decryptedBallot = decryptedBallotResult.unwrap()
             decryptTime += getSystemTimeInMillis() - startDecrypt
 
@@ -217,6 +217,6 @@ class DecryptionWithNonceTest {
 
         val encryptPerBallot = (encryptTime.toDouble() / nb).roundToInt()
         val decryptPerBallot = (decryptTime.toDouble() / nb).roundToInt()
-        println("testDecryptionWithMasterNonce for $nballots ballots took $encryptPerBallot encrypt, $decryptPerBallot decrypt msecs/ballot")
+        println("testDecryptionWithPrimaryNonce for $nballots ballots took $encryptPerBallot encrypt, $decryptPerBallot decrypt msecs/ballot")
     }
 }

--- a/egklib/src/commonTest/kotlin/electionguard/encrypt/EncryptionNonceTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/encrypt/EncryptionNonceTest.kt
@@ -46,8 +46,8 @@ class EncryptionNonceTest {
         val starting = getSystemTimeInMillis()
         RandomBallotProvider(electionInit.manifest(), nballots).ballots().forEach { ballot ->
             val codeSeed = group.randomElementModQ(minimum = 2)
-            val masterNonce = group.randomElementModQ(minimum = 2)
-            val ciphertextBallot = encryptor.encrypt(ballot, codeSeed, masterNonce, 0)
+            val primaryNonce = group.randomElementModQ(minimum = 2)
+            val ciphertextBallot = encryptor.encrypt(ballot, codeSeed, primaryNonce, 0)
 
             // decrypt with nonces
             val decryptionWithNonce = VerifyEmbeddedNonces(group, electionInit.manifest(), electionInit.jointPublicKey())
@@ -100,7 +100,7 @@ fun compareBallots(ballot: PlaintextBallot, decryptedBallot: PlaintextBallot) {
 class VerifyEmbeddedNonces(val group : GroupContext, val manifest: Manifest, val publicKey: ElGamalPublicKey) {
 
     fun CiphertextBallot.decrypt(): PlaintextBallot {
-        val ballotNonce: UInt256 = hashElements(manifest.cryptoHash, this.ballotId, this.masterNonce)
+        val ballotNonce: UInt256 = hashElements(manifest.cryptoHash, this.ballotId, this.primaryNonce)
 
         val plaintext_contests = mutableListOf<PlaintextBallot.Contest>()
         for (contest in this.contests) {

--- a/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorTest.kt
@@ -1,0 +1,224 @@
+package electionguard.preencrypt
+
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.unwrap
+import electionguard.ballot.ElectionInitialized
+import electionguard.ballot.Manifest
+import electionguard.core.ElGamalPublicKey
+import electionguard.core.UInt256
+import electionguard.core.hashElements
+import electionguard.core.productionGroup
+import electionguard.core.randomElementModQ
+import electionguard.core.runTest
+import electionguard.core.toElementModQ
+import electionguard.core.toUInt256
+import electionguard.encrypt.cast
+import electionguard.input.ManifestInputBuilder
+import electionguard.protoconvert.importEncryptedBallot
+import electionguard.protoconvert.publishEncryptedBallot
+import electionguard.publish.Consumer
+import electionguard.verifier.VerifyEncryptedBallots
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+private val random = Random
+private const val codeLen = 4
+
+internal class PreEncryptorTest {
+    val input = "src/commonTest/data/runWorkflowAllAvailable"
+
+    // sanity check that PreEncryptor.preencrypt doesnt barf
+    @Test
+    fun testPreencrypt() {
+        runTest {
+            val group = productionGroup()
+            val consumerIn = Consumer(input, group)
+            val electionInit: ElectionInitialized =
+                consumerIn.readElectionInitialized().getOrThrow { IllegalStateException(it) }
+            val manifest = electionInit.manifest()
+
+            val preEncryptor =
+                PreEncryptor(group, manifest, electionInit.jointPublicKey())
+
+            manifest.ballotStyles.forEach { println(it) }
+
+            val pballot = preEncryptor.preencrypt("testPreencrypt_ballot_id", "styling", 11U.toUInt256())
+            pballot.show()
+        }
+    }
+
+    // sanity check that Recorder.record doesnt barf
+    @Test
+    fun testRecord() {
+        runTest {
+            val group = productionGroup()
+            val consumerIn = Consumer(input, group)
+            val electionInit: ElectionInitialized =
+                consumerIn.readElectionInitialized().getOrThrow { IllegalStateException(it) }
+            val manifest = electionInit.manifest()
+
+            val preEncryptor =
+                PreEncryptor(group, manifest, electionInit.jointPublicKey())
+
+            manifest.ballotStyles.forEach { println(it) }
+
+            val primaryNonce = 42U.toUInt256()
+            val pballot = preEncryptor.preencrypt("testDecrypt_ballot_id", "styling", primaryNonce)
+            pballot.show()
+
+            val mballot = markBallotChooseOne(manifest, pballot)
+            mballot.show()
+
+            val recorder = Recorder(group, manifest, electionInit.jointPublicKey(), electionInit.cryptoExtendedBaseHash)
+
+            val ciphertextBallot = with(recorder) {
+                mballot.record(UInt256.TWO, primaryNonce, codeLen)
+            }
+        }
+    }
+
+    // check that CiphertextBallot is correctly formed
+    @Test
+    fun testSingleLimit() {
+        runTest {
+            val ebuilder = ManifestInputBuilder("testSingleLimit")
+            val manifest: Manifest = ebuilder.addContest("onlyContest")
+                .addSelection("selection1", "candidate1")
+                .addSelection("selection2", "candidate2")
+                .done()
+                .build()
+
+            runComplete("testSingleLimit", manifest, this::markBallotChooseOne, true)
+        }
+    }
+
+    // multiple selections per contest
+    @Test
+    fun testMultipleSelections() {
+        runTest {
+            val ebuilder = ManifestInputBuilder("testMultipleSelections")
+            val manifest: Manifest = ebuilder.addContest("onlyContest")
+                .setVoteVariationType(Manifest.VoteVariationType.n_of_m, 2)
+                .addSelection("selection1", "candidate1")
+                .addSelection("selection2", "candidate2")
+                .addSelection("selection3", "candidate3")
+                .done()
+                .build()
+
+            runComplete("testMultipleSelections", manifest, this::markBallotToLimit, false)
+        }
+    }
+
+    fun runComplete(
+        ballot_id: String,
+        manifest: Manifest,
+        markBallot: (manifest: Manifest, pballot: PreEncryptedBallot) -> MarkedPreEncryptedBallot,
+        isLimitOne: Boolean,
+    ) {
+        val group = productionGroup()
+
+        val qbar = 4242U.toUInt256()
+        val secret = group.randomElementModQ(minimum = 1)
+        val publicKey = ElGamalPublicKey(group.gPowP(secret))
+
+        // pre-encrypt
+        val preEncryptor =
+            PreEncryptor(group, manifest, publicKey)
+        val primaryNonce = 42U.toUInt256()
+        val pballot = preEncryptor.preencrypt(ballot_id, "styling", primaryNonce)
+
+        // vote
+        val mballot = markBallot(manifest, pballot)
+        mballot.show()
+
+        // record
+        val recorder = Recorder(group, manifest, publicKey, qbar)
+        val (recordedBallot, ciphertextBallot) = with(recorder) {
+            mballot.record(UInt256.TWO, primaryNonce, codeLen)
+        }
+
+        val mcontests = mballot.contests.associateBy { it.contestId }
+        println("\nCiphertextBallot ${ciphertextBallot.ballotId}")
+        for (contest in ciphertextBallot.contests) {
+            println(" contest ${contest.contestId}")
+            if (isLimitOne) {
+                val ve = contest.selections.filter { !it.isPlaceholderSelection }.map { it.ciphertext }
+                val hv = hashElements(ve)
+                contest.selections.forEach { println("   ${it.selectionId} = ${it.ciphertext.cryptoHashUInt256().cryptoHashString()}")}
+
+                val mcontest =
+                    mcontests[contest.contestId] ?: throw IllegalArgumentException("Unknown contest $contest.contestId")
+                mcontest.selectedCodes.forEach {
+                    println("  hv = ${hv.cryptoHashString()} endsWith $it")
+                    assertTrue(hv.cryptoHashString().endsWith(it))
+                }
+            }
+        }
+
+        recordedBallot.show()
+        val encryptedBallot = ciphertextBallot.cast()
+
+        // roundtrip
+        val proto = encryptedBallot.publishEncryptedBallot(recordedBallot)
+        // combines the recordedBallot
+        val fullEncryptedBallot = group.importEncryptedBallot(proto).unwrap()
+
+        val verifier = VerifyEncryptedBallots(group, manifest, publicKey, qbar.toElementModQ(group), 1)
+        val stats = verifier.verifyEncryptedBallot(fullEncryptedBallot)
+        println("VerifyEncryptedBallots $stats")
+        assertTrue(stats.result is Ok)
+    }
+
+    fun markBallotChooseOne(manifest: Manifest, pballot: PreEncryptedBallot): MarkedPreEncryptedBallot {
+        val pcontests = mutableListOf<MarkedPreEncryptedContest>()
+        for (pcontest in pballot.contests) {
+            val n = pcontest.selections.size
+            val idx = random.nextInt(n)
+            val pselection = pcontest.selections[idx]
+            pcontests.add(
+                MarkedPreEncryptedContest(
+                    pcontest.contestId,
+                    listOf(pselection.choose(codeLen)),
+                )
+            )
+        }
+
+        return MarkedPreEncryptedBallot(
+            pballot.ballotId,
+            pballot.ballotStyleId,
+            pcontests,
+        )
+    }
+
+    // pick all selections 0..limit-1
+    fun markBallotToLimit(manifest: Manifest, pballot: PreEncryptedBallot): MarkedPreEncryptedBallot {
+        val pcontests = mutableListOf<MarkedPreEncryptedContest>()
+        for (pcontest in pballot.contests) {
+            val mcontest = manifest.contests.find { it.contestId == pcontest.contestId }
+                ?: throw IllegalArgumentException("Cant find $pcontest.contestId")
+            val selections = mutableListOf<String>()
+            for (idx in 0 until mcontest.votesAllowed) {
+                selections.add(pcontest.selections[idx].choose(codeLen))
+            }
+            pcontests.add(
+                MarkedPreEncryptedContest(
+                    pcontest.contestId,
+                    selections,
+                )
+            )
+        }
+
+        return MarkedPreEncryptedBallot(
+            pballot.ballotId,
+            pballot.ballotStyleId,
+            pcontests,
+        )
+    }
+
+    fun PreEncryptedSelection.choose(len: Int): String {
+        val match = this.preencryptionHash.cryptoHashString()
+        return match.substring(match.length - len) // arbitrary, for testing purposes
+    }
+}


### PR DESCRIPTION
Add EncryptedBallot.isPreEncrypt, Contest.preEncryption. 
Encryptor.encryptBallot now takes an optional confirmationCode override, used by the Preencryptor. 
Changes to VerifyEncryptedBallots (incomplete).
Not done - waiting for spec.