### PR TITLE
Improve keyCeremonyExchange.

### DIFF
--- a/egklib/build.gradle.kts
+++ b/egklib/build.gradle.kts
@@ -121,6 +121,9 @@ kotlin {
 
                     // Fancy property-based testing
                     implementation(libs.kotest.property)
+
+                    // mocking
+                    implementation("io.mockk:mockk:1.13.2")
                 }
             }
         val jvmMain by

--- a/egklib/src/commonMain/kotlin/electionguard/core/Utils.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Utils.kt
@@ -162,7 +162,7 @@ inline fun <T> List<Result<T, String>>.mergeWithOkay(
             else
                 ""
         Err(errHeaderWithNewline +
-                errors.joinToString("\n") { it.error })
+                errors.joinToString("\n ") { it.error })
     }
 }
 

--- a/egklib/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrustee.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrustee.kt
@@ -17,9 +17,9 @@ import electionguard.keyceremony.EncryptedKeyShare
 data class DecryptingTrustee(
     val id: String,
     val xCoordinate: Int,
-    // This guardian's private and public key
+    // My private and public key
     val electionKeypair: ElGamalKeypair,
-    // Guardian's "shares" of other guardians keys, keyed by other (missing) guardian's id.
+    // My share of other's key, keyed by other guardian id.
     val encryptedKeyShares: Map<String, EncryptedKeyShare>,
 ) : DecryptingTrusteeIF {
 

--- a/egklib/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeIF.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/decrypt/DecryptingTrusteeIF.kt
@@ -27,7 +27,7 @@ interface DecryptingTrusteeIF {
     ) : Boolean
 
     /**
-     * Compute partial decryption(s) of elgamal encryption(s), using spec 1.52 eq 58 and 59.
+     * Compute partial decryptions of elgamal encryptions, using spec 1.52 eq 58 and 59.
      *
      * @param texts            list of ElementModP that will be partially decrypted
      * @param nonce            an optional nonce to generate the proof

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/ElectionPolynomial.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/ElectionPolynomial.kt
@@ -49,7 +49,7 @@ data class ElectionPolynomial(
  */
 fun calculateGexpPiAtL(
     xcoord: Int,  // l
-    coefficientCommitments: List<ElementModP>  // the committments to Pi
+    coefficientCommitments: List<ElementModP>  // K_i,j
 ): ElementModP {
     val group = compatibleContextOrFail(*coefficientCommitments.toTypedArray())
     val xcoordQ: ElementModQ = group.uIntToElementModQ(xcoord.toUInt())

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeIF.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeIF.kt
@@ -15,10 +15,11 @@ interface KeyCeremonyTrusteeIF {
     fun publicKeys(): Result<PublicKeys, String>
     /** Receive the PublicKeys from another guardian. */
     fun receivePublicKeys(publicKeys: PublicKeys): Result<Boolean, String>
-    /** Create another guardians share of my key. */
-    fun secretKeyShareFor(otherGuardian: String): Result<EncryptedKeyShare, String>
-    /** Receive and verify a secret key share. */
-    fun receiveSecretKeyShare(share: EncryptedKeyShare): Result<Boolean, String>
+
+    /** Create another guardians share of my key, encrypted. */
+    fun encryptedKeyShareFor(otherGuardian: String): Result<EncryptedKeyShare, String>
+    /** Receive and verify an encrypted key share. */
+    fun receiveEncryptedKeyShare(share: EncryptedKeyShare): Result<Boolean, String>
 
     /** Create another guardians share of my key, not encrypted. */
     fun keyShareFor(otherGuardian: String): Result<KeyShare, String>

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/RunTrustedKeyCeremony.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/RunTrustedKeyCeremony.kt
@@ -1,6 +1,8 @@
 package electionguard.keyceremony
 
 import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrThrow
 import com.github.michaelbull.result.unwrap
 import electionguard.ballot.ElectionConfig
@@ -44,7 +46,8 @@ fun main(args: Array<String>) {
     println("RunTrustedKeyCeremony starting\n   input= $inputDir\n   trustees= $trusteeDir\n   output = $outputDir")
 
     val group = productionGroup()
-    runKeyCeremony(group, inputDir, outputDir, trusteeDir, createdBy)
+    val result = runKeyCeremony(group, inputDir, outputDir, trusteeDir, createdBy)
+    println("runKeyCeremony result = $result")
 }
 
 fun runKeyCeremony(
@@ -53,7 +56,7 @@ fun runKeyCeremony(
     outputDir: String,
     trusteeDir: String,
     createdBy: String?
-): Boolean {
+): Result<Boolean, String> {
     val starting = getSystemTimeInMillis()
 
     val consumerIn = Consumer(configDir, group)
@@ -67,8 +70,7 @@ fun runKeyCeremony(
 
     val exchangeResult = keyCeremonyExchange(trustees)
     if (exchangeResult is Err) {
-        println(exchangeResult.error)
-        return false
+        return exchangeResult
     }
     val keyCeremonyResults = exchangeResult.unwrap()
     val electionInitialized = keyCeremonyResults.makeElectionInitialized(
@@ -88,5 +90,5 @@ fun runKeyCeremony(
 
     val took = getSystemTimeInMillis() - starting
     println("RunTrustedKeyCeremony took $took millisecs")
-    return true
+    return Ok(true)
 }

--- a/egklib/src/commonMain/kotlin/electionguard/protoconvert/DecryptingTrusteeConvert.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/protoconvert/DecryptingTrusteeConvert.kt
@@ -15,7 +15,6 @@ import electionguard.decrypt.DecryptingTrustee
 import electionguard.keyceremony.KeyCeremonyTrustee
 import electionguard.keyceremony.EncryptedKeyShare
 
-// DecryptingTrustee must stay private. DecryptingGuardian is its public info.
 fun GroupContext.importDecryptingTrustee(proto: electionguard.protogen.DecryptingTrustee):
         Result<DecryptingTrustee, String> {
 

--- a/egklib/src/commonTest/kotlin/electionguard/decrypt/EncryptDecryptTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decrypt/EncryptDecryptTest.kt
@@ -64,7 +64,7 @@ fun runRecoveredDecryption52(
     // exchange SecretKeyShares
     trustees.forEach { t1 ->
         trustees.filter { it.id != t1.id }.forEach { t2 ->
-            t2.receiveSecretKeyShare(t1.secretKeyShareFor(t2.id).unwrap())
+            t2.receiveEncryptedKeyShare(t1.encryptedKeyShareFor(t2.id).unwrap())
         }
     }
 

--- a/egklib/src/commonTest/kotlin/electionguard/decrypt/MissingGuardianTests.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decrypt/MissingGuardianTests.kt
@@ -47,7 +47,7 @@ fun testMissingGuardians(present: List<Int>) {
     // exchange SecretKeyShares
     trustees.forEach { t1 ->
         trustees.filter { it.id != t1.id }. forEach { t2 ->
-            t2.receiveSecretKeyShare(t1.secretKeyShareFor(t2.id).unwrap())
+            t2.receiveEncryptedKeyShare(t1.encryptedKeyShareFor(t2.id).unwrap())
         }
     }
 

--- a/egklib/src/commonTest/kotlin/electionguard/decryptBallot/EncryptDecryptBallotTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decryptBallot/EncryptDecryptBallotTest.kt
@@ -80,7 +80,7 @@ fun runEncryptDecryptBallot(
     }
     trustees.forEach { t1 ->
         trustees.filter { it.id != t1.id }.forEach { t2 ->
-            t2.receiveSecretKeyShare(t1.secretKeyShareFor(t2.id).unwrap())
+            t2.receiveEncryptedKeyShare(t1.encryptedKeyShareFor(t2.id).unwrap())
         }
     }
     val dTrustees: List<DecryptingTrustee> = trustees.map { makeDecryptingTrustee(it) }

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyMockTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyMockTest.kt
@@ -1,0 +1,133 @@
+package electionguard.keyceremony
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.unwrap
+import electionguard.core.productionGroup
+import electionguard.protoconvert.generateHashedCiphertext
+import io.mockk.every
+import io.mockk.spyk
+import kotlin.test.Test
+
+import kotlin.test.assertTrue
+
+class KeyCeremonyMockTest {
+
+    @Test
+    fun testKeyCeremonyOk() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val spy3 = spyk(trustee3)
+        val trustees = listOf(trustee1, trustee2, spy3)
+
+        val result = keyCeremonyExchange(trustees)
+        assertTrue(result is Ok)
+    }
+
+    @Test
+    fun testKeyCeremonyMockOk() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val spy3 = spyk(trustee3)
+        every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
+            val result1 = trustee3.encryptedKeyShareFor(trustee1.id())
+            assertTrue(result1 is Ok)
+            val ss21 = result1.unwrap()
+            Ok(EncryptedKeyShare(spy3.id(), trustee1.id(), ss21.encryptedCoordinate))
+        }
+        val trustees = listOf(trustee1, trustee2, spy3)
+
+        val result = keyCeremonyExchange(trustees)
+        assertTrue(result is Ok)
+    }
+
+    @Test
+    fun testAllowBadEncryptedShare() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val spy3 = spyk(trustee3)
+        every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
+            trustee3.encryptedKeyShareFor(trustee1.id())
+            // bad EncryptedShare
+            Ok(EncryptedKeyShare(spy3.id(), trustee1.id(), generateHashedCiphertext(group)))
+        }
+        val trustees = listOf(trustee1, trustee2, spy3)
+        val result = keyCeremonyExchange(trustees, true)
+        println("result = $result")
+        assertTrue(result is Ok)
+    }
+
+    @Test
+    fun testBadEncryptedShare() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val spy3 = spyk(trustee3)
+        every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
+            trustee3.encryptedKeyShareFor(trustee1.id())
+            // bad EncryptedShare
+            Ok(EncryptedKeyShare(spy3.id(), trustee1.id(), generateHashedCiphertext(group)))
+        }
+        val trustees = listOf(trustee1, trustee2, spy3)
+        val result = keyCeremonyExchange(trustees, false)
+        println("result = $result")
+        assertTrue(result is Err)
+        assertTrue(result.error.contains("Trustee 'id1' couldnt decrypt EncryptedKeyShare for missingGuardianId 'id3'"))
+    }
+
+    @Test
+    fun testBadKeySharesAllowFalse() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val spy3 = spyk(trustee3)
+        every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
+            trustee3.encryptedKeyShareFor(trustee1.id())
+            // bad EncryptedShare
+            Ok(EncryptedKeyShare(spy3.id(), trustee1.id(), generateHashedCiphertext(group)))
+        }
+        every { spy3.keyShareFor(trustee1.id()) } answers {
+            // bad KeyShare
+            Ok(KeyShare(spy3.id(), trustee1.id(), group.TWO_MOD_Q, group.TWO_MOD_Q))
+        }
+        val trustees = listOf(trustee1, trustee2, spy3)
+        val result = keyCeremonyExchange(trustees, false)
+        println("result = $result")
+        assertTrue(result is Err)
+        assertTrue(result.error.contains("Trustee 'id1' couldnt decrypt EncryptedKeyShare for missingGuardianId 'id3'"))
+        assertTrue(result.error.contains("Trustee 'id1' failed to validate KeyShare for missingGuardianId 'id3'"))
+    }
+
+    @Test
+    fun testBadKeySharesAllowTrue() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 3)
+        val spy3 = spyk(trustee3)
+        every { spy3.encryptedKeyShareFor(trustee1.id()) } answers {
+            trustee3.encryptedKeyShareFor(trustee1.id())
+            // bad EncryptedShare
+            Ok(EncryptedKeyShare(spy3.id(), trustee1.id(), generateHashedCiphertext(group)))
+        }
+        every { spy3.keyShareFor(trustee1.id()) } answers {
+            // bad KeyShare
+            Ok(KeyShare(spy3.id(), trustee1.id(), group.TWO_MOD_Q, group.TWO_MOD_Q))
+        }
+        val trustees = listOf(trustee1, trustee2, spy3)
+        val result = keyCeremonyExchange(trustees, true)
+        println("result = $result")
+        assertTrue(result is Err)
+        assertTrue(result.error.contains("Trustee 'id1' couldnt decrypt EncryptedKeyShare for missingGuardianId 'id3'"))
+        assertTrue(result.error.contains("Trustee 'id1' failed to validate KeyShare for missingGuardianId 'id3'"))
+    }
+
+}

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTest.kt
@@ -1,5 +1,6 @@
 package electionguard.keyceremony
 
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.getError
 import electionguard.ballot.ElectionConfig
@@ -76,4 +77,47 @@ class KeyCeremonyTest {
         assertEquals(expectedExtendedBaseHash.toElementModQ(group), init.cryptoExtendedBaseHash())
         assertEquals(config.numberOfGuardians, init.numberOfGuardians())
     }
+
+    @Test
+    fun testKeyCeremonyFailQuorum() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 2, 2)
+        val trustees = listOf(trustee1, trustee2, trustee3)
+
+        val result = keyCeremonyExchange(trustees)
+        println("result = ${result.getError()}")
+        assertTrue(result is Err, result.getError())
+        assertTrue(result.toString().contains("keyCeremonyExchange trustees have different quorums"))
+    }
+
+    @Test
+    fun testKeyCeremonyFailTrusteeIdDuplicate() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id1", 2, 3)
+        val trustees = listOf(trustee1, trustee2, trustee3)
+
+        val result = keyCeremonyExchange(trustees)
+        println("result = ${result.getError()}")
+        assertTrue(result is Err, result.getError())
+        assertTrue(result.toString().contains("keyCeremonyExchange trustees have non-unique ids"))
+    }
+
+    @Test
+    fun testKeyCeremonyFailTrusteeCoordDuplicate() {
+        val group = productionGroup()
+        val trustee1 = KeyCeremonyTrustee(group, "id1", 1, 3)
+        val trustee2 = KeyCeremonyTrustee(group, "id2", 3, 3)
+        val trustee3 = KeyCeremonyTrustee(group, "id3", 3, 3)
+        val trustees = listOf(trustee1, trustee2, trustee3)
+
+        val result = keyCeremonyExchange(trustees)
+        println("result = ${result.getError()}")
+        assertTrue(result is Err, result.getError())
+        assertTrue(result.toString().contains("keyCeremonyExchange trustees have non-unique xcoordinates"))
+    }
+
 }

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeTest.kt
@@ -39,7 +39,7 @@ class KeyCeremonyTrusteeTest {
 
         val result1 = trustee1.receivePublicKeys(trustee2.publicKeys().unwrap())
         assertTrue(result1 is Err)
-        assertEquals("id2: must have quorum (4) coefficientProofs", result1.error)
+        assertEquals("id1 receivePublicKeys from 'id2': needs (4) coefficientProofs", result1.error)
     }
 
     @Test
@@ -48,7 +48,7 @@ class KeyCeremonyTrusteeTest {
         val trustee1 = KeyCeremonyTrustee(group, "id1", 41, 4)
         val result1 = trustee1.receivePublicKeys(trustee1.publicKeys().unwrap())
         assertTrue(result1 is Err)
-        assertEquals("Cant send id1 public keys to itself", result1.error)
+        assertEquals("Cant send 'id1' public keys to itself", result1.error)
     }
 
     @Test
@@ -75,28 +75,28 @@ class KeyCeremonyTrusteeTest {
         val result1 = trustee1.receivePublicKeys(trustee2.publicKeys().unwrap())
         assertTrue(result1 is Ok)
 
-        val result1b = trustee1.secretKeyShareFor("bad")
+        val result1b = trustee1.encryptedKeyShareFor("bad")
         assertTrue(result1b is Err)
         assertEquals("Trustee 'id1', does not have public key for 'bad'", result1b.error)
 
         /** Create trustee1 SecretKeyShare for trustee2. */
-        val result2 = trustee1.secretKeyShareFor(trustee2.id())
-        assertTrue(result2 is Ok)
+        val result2 = trustee1.encryptedKeyShareFor(trustee2.id())
+        assertTrue(result2 is Ok, result2.toString())
         val ss2 = result2.unwrap()
         assertEquals(trustee1.id(), ss2.missingGuardianId)
         assertEquals(trustee2.id(), ss2.availableGuardianId)
 
-        val result3 = trustee2.receiveSecretKeyShare(ss2)
+        val result3 = trustee2.receiveEncryptedKeyShare(ss2)
         assertTrue(result3 is Err)
-        assertEquals("Trustee id2 does not have public keys for missingGuardianId id1", result3.error)
+        assertEquals("Trustee 'id2' does not have public keys for missingGuardianId 'id1'", result3.error)
 
         trustee2.receivePublicKeys(trustee1.publicKeys().unwrap())
-        val result4 = trustee2.receiveSecretKeyShare(ss2)
+        val result4 = trustee2.receiveEncryptedKeyShare(ss2)
         assertTrue(result4 is Ok)
 
-        val result5 = trustee1.receiveSecretKeyShare(ss2)
+        val result5 = trustee1.receiveEncryptedKeyShare(ss2)
         assertTrue(result5 is Err)
-        assertEquals("Sent SecretKeyShare to wrong trustee id1, should be availableGuardianId id2", result5.error)
+        assertEquals("Sent EncryptedKeyShare to wrong trustee 'id1', should be availableGuardianId 'id2'", result5.error)
     }
 
     @Test
@@ -109,33 +109,33 @@ class KeyCeremonyTrusteeTest {
         assertTrue(trustee2.receivePublicKeys(trustee1.publicKeys().unwrap()) is Ok)
 
         /** Create trustee1 SecretKeyShare for trustee2, send to trustee2. */
-        val result2 = trustee1.secretKeyShareFor(trustee2.id())
-        assertTrue(result2 is Ok)
+        val result2 = trustee1.encryptedKeyShareFor(trustee2.id())
+        assertTrue(result2 is Ok, result2.toString())
         val ss12 = result2.unwrap()
-        val result3 = trustee2.receiveSecretKeyShare(ss12)
+        val result3 = trustee2.receiveEncryptedKeyShare(ss12)
         assertTrue(result3 is Ok)
 
         /** Create trustee2 SecretKeyShare for trustee1, send to trustee1. */
-        val result1 = trustee2.secretKeyShareFor(trustee1.id())
+        val result1 = trustee2.encryptedKeyShareFor(trustee1.id())
         assertTrue(result1 is Ok)
         val ss21 = result1.unwrap()
-        val result4 = trustee1.receiveSecretKeyShare(ss21)
+        val result4 = trustee1.receiveEncryptedKeyShare(ss21)
         assertTrue(result4 is Ok)
 
         // mess this one up so it wont decrypt
         val ss2b1 = ss21.copy(encryptedCoordinate = ss12.encryptedCoordinate)
-        val result5 = trustee1.receiveSecretKeyShare(ss2b1)
+        val result5 = trustee1.receiveEncryptedKeyShare(ss2b1)
         assertTrue(result5 is Err)
-        assertEquals("Trustee id1 couldnt decrypt SecretKeyShare for missingGuardianId id2", result5.error)
+        assertEquals("Trustee 'id1' couldnt decrypt EncryptedKeyShare for missingGuardianId 'id2'", result5.error)
 
         // mess this one up so it wont validate
         val trustee3 = KeyCeremonyTrustee(group, "id3", 43, 4)
         assertTrue(trustee1.receivePublicKeys(trustee3.publicKeys().unwrap()) is Ok)
         // give it the wrong generatingGuardianId
         val ss2v1 = ss21.copy(missingGuardianId = "id3")
-        val result7 = trustee1.receiveSecretKeyShare(ss2v1)
+        val result7 = trustee1.receiveEncryptedKeyShare(ss2v1)
         assertTrue(result7 is Err)
-        assertEquals("Trustee id1 failed to validate SecretKeyShare for missingGuardianId id3", result7.error)
+        assertEquals("Trustee 'id1' failed to validate EncryptedKeyShare for missingGuardianId 'id3'", result7.error)
     }
 
     @Test
@@ -148,20 +148,20 @@ class KeyCeremonyTrusteeTest {
         assertTrue(trustee2.receivePublicKeys(trustee1.publicKeys().unwrap()) is Ok)
 
         /** Create trustee1 SecretKeyShare for trustee2. */
-        val result2 = trustee1.secretKeyShareFor(trustee2.id())
-        assertTrue(result2 is Ok)
+        val result2 = trustee1.encryptedKeyShareFor(trustee2.id())
+        assertTrue(result2 is Ok, result2.toString())
         val result3 = trustee1.keyShareFor(trustee2.id())
         assertTrue(result3 is Ok)
 
         /** Create trustee2 SecretKeyShare for trustee1. */
-        val result4 = trustee2.secretKeyShareFor(trustee1.id())
+        val result4 = trustee2.encryptedKeyShareFor(trustee1.id())
         assertTrue(result4 is Ok)
         val result5 = trustee2.keyShareFor(trustee1.id())
         assertTrue(result5 is Ok)
 
         val result6 = trustee1.keyShareFor("bad")
         assertTrue(result6 is Err)
-        assertEquals("Trustee 'id1', does not have KeyShare for 'bad'", result6.error)
+        assertEquals("Trustee 'id1', does not have KeyShare for 'bad'; must call encryptedKeyShareFor() first", result6.error)
     }
 
     @Test
@@ -174,14 +174,14 @@ class KeyCeremonyTrusteeTest {
         assertTrue(trustee2.receivePublicKeys(trustee1.publicKeys().unwrap()) is Ok)
 
         /** Create trustee1 SecretKeyShare for trustee2. */
-        val result1 = trustee1.secretKeyShareFor(trustee2.id())
-        assertTrue(result1 is Ok)
-        assertTrue(trustee2.receiveSecretKeyShare(result1.unwrap()) is Ok)
+        val result1 = trustee1.encryptedKeyShareFor(trustee2.id())
+        assertTrue(result1 is Ok, result1.toString())
+        assertTrue(trustee2.receiveEncryptedKeyShare(result1.unwrap()) is Ok)
 
         /** Create trustee2 SecretKeyShare for trustee1. */
-        val result2 = trustee2.secretKeyShareFor(trustee1.id())
+        val result2 = trustee2.encryptedKeyShareFor(trustee1.id())
         assertTrue(result2 is Ok)
-        assertTrue(trustee1.receiveSecretKeyShare(result2.unwrap()) is Ok)
+        assertTrue(trustee1.receiveEncryptedKeyShare(result2.unwrap()) is Ok)
 
         // challenge those by asking for the unencrypted version
         val result3 = trustee1.keyShareFor(trustee2.id())
@@ -200,26 +200,27 @@ class KeyCeremonyTrusteeTest {
         // give it to the wrong trustee
         val resultWrongTrustee = trustee1.receiveKeyShare(keyShare12)
         assertTrue(resultWrongTrustee is Err)
-        assertEquals("Sent KeyShare to wrong trustee id1, should be availableGuardianId id2", resultWrongTrustee.error)
+        assertEquals("Sent KeyShare to wrong trustee 'id1', should be availableGuardianId 'id2'", resultWrongTrustee.error)
 
         // Give it a bad guardian id
         val keyShareBadId = keyShare12.copy(missingGuardianId = "badId")
         val resultBadId = trustee2.receiveKeyShare(keyShareBadId)
         assertTrue(resultBadId is Err)
         assertTrue(resultBadId.error.contains("Trustee 'id2', does not have public key for missingGuardianId 'badId'"))
-        assertTrue(resultBadId.error.contains("Trustee 'id2', does not have encryptedKeyShare for missingGuardianId 'badId'"))
 
-        // Give it a bad nonce
+        /* Give it a bad nonce LOOK this is disabled in receiveKeyShare()
         val keyShareBadNonce = keyShare12.copy(nonce = group.TWO_MOD_Q)
         val resultBadNonce = trustee2.receiveKeyShare(keyShareBadNonce)
         assertTrue(resultBadNonce is Err)
-        assertEquals("Trustee id2 couldnt decrypt encryptedKeyShare for missingGuardianId id1", resultBadNonce.error)
+        assertEquals("Trustee 'id2' couldnt decrypt encryptedKeyShare for missingGuardianId 'id1'", resultBadNonce.error)
+
+         */
 
         // Give it a bad coordinate
         val keyShareBadCoordinate = keyShare12.copy(coordinate = group.TWO_MOD_Q)
         val resultBadCoordinate = trustee2.receiveKeyShare(keyShareBadCoordinate)
         assertTrue(resultBadCoordinate is Err)
-        assertTrue(resultBadCoordinate.error.contains("Trustee id2 couldnt decrypt encryptedKeyShare for missingGuardianId id1"))
-        assertTrue(resultBadCoordinate.error.contains("Trustee id2 failed to validate KeyShare for missingGuardianId id1"))
+        println("result = $resultBadCoordinate")
+        assertTrue(resultBadCoordinate.error.contains("Trustee 'id2' failed to validate KeyShare for missingGuardianId 'id1'"))
     }
 }

--- a/webapps/keyceremony/src/main/kotlin/webapps/electionguard/keyceremony/RemoteKeyTrusteeProxy.kt
+++ b/webapps/keyceremony/src/main/kotlin/webapps/electionguard/keyceremony/RemoteKeyTrusteeProxy.kt
@@ -76,7 +76,7 @@ class RemoteKeyTrusteeProxy(
         }
     }
 
-    override fun secretKeyShareFor(otherGuardian: String): Result<EncryptedKeyShare, String> {
+    override fun encryptedKeyShareFor(otherGuardian: String): Result<EncryptedKeyShare, String> {
         return runBlocking {
             val url = "$remoteURL/ktrustee/$xcoord/$otherGuardian/secretKeyShareFor"
             val response: HttpResponse = client.get(url) {
@@ -91,7 +91,7 @@ class RemoteKeyTrusteeProxy(
         }
     }
 
-    override fun receiveSecretKeyShare(share: EncryptedKeyShare): Result<Boolean, String> {
+    override fun receiveEncryptedKeyShare(share: EncryptedKeyShare): Result<Boolean, String> {
         return runBlocking {
             val url = "$remoteURL/ktrustee/$xcoord/receiveSecretKeyShare"
             val response: HttpResponse = client.post(url) {

--- a/webapps/keyceremonytrustee/src/main/kotlin/webapps/electionguard/models/RemoteKeyTrustees.kt
+++ b/webapps/keyceremonytrustee/src/main/kotlin/webapps/electionguard/models/RemoteKeyTrustees.kt
@@ -24,8 +24,8 @@ data class RemoteKeyTrustee(val id: String, val xCoordinate: Int, val quorum: In
 
     fun publicKeys() = delegate.publicKeys()
     fun receivePublicKeys(keys: PublicKeys) = delegate.receivePublicKeys(keys)
-    fun secretKeyShareFor(forGuardian: String) = delegate.secretKeyShareFor(forGuardian)
-    fun receiveSecretKeyShare(share: EncryptedKeyShare) = delegate.receiveSecretKeyShare(share)
+    fun secretKeyShareFor(forGuardian: String) = delegate.encryptedKeyShareFor(forGuardian)
+    fun receiveSecretKeyShare(share: EncryptedKeyShare) = delegate.receiveEncryptedKeyShare(share)
     fun keyShareFor(otherGuardian: String): Result<KeyShare, String> = delegate.keyShareFor(otherGuardian)
     fun receiveKeyShare(keyShare: KeyShare): Result<Boolean, String> = delegate.receiveKeyShare(keyShare)
     fun saveState() = delegate.saveState()


### PR DESCRIPTION
Add allowEncryptedFailure parameter to keyCeremonyExchange, default true.
rename secretKeyShareFor() to encryptedKeyShareFor() et al. 
Add mock tests.