### PR TITLE
Hash ByteArray by converting to hex string.

### DIFF
--- a/egklib/src/commonMain/kotlin/electionguard/decrypt/Decryptor.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/decrypt/Decryptor.kt
@@ -6,6 +6,7 @@ import electionguard.ballot.EncryptedBallot
 import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.ballot.Guardian
 import electionguard.core.*
+import electionguard.core.Base16.toHex
 
 // TODO Use a configuration to set to the maximum possible vote. Keep low for testing to detect bugs quickly.
 private const val maxDlog: Int = 1000
@@ -100,7 +101,7 @@ class Decryptor(
                     qbar,
                     jointPublicKey,
                     results.ciphertext.c0,
-                    // results.ciphertext.c1, // TODO how to hash byte array ?
+                    results.ciphertext.c1.toHex(),
                     results.ciphertext.c2,
                     a,
                     b,

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
@@ -160,6 +160,28 @@ class KeyCeremonyTrustee(
             return Err("Sent KeyShare to wrong trustee '${this.id}', should be availableGuardianId '${keyShare.availableGuardianId}'")
         }
 
+        /* spec 1.52 says:
+        If the recipient guardian Tℓ reports not receiving a suitable value Pi (ℓ), it becomes incumbent on the
+        sending guardian Ti to publish this Pi (ℓ) together with the nonce Ri,ℓ it used to encrypt Pi (ℓ)
+        under the public key Kℓ of recipient guardian Tℓ . If guardian Ti fails to produce a suitable Pi (ℓ)
+        and nonce Ri,ℓ that match both the published encryption and the above equation, it should be
+        excluded from the election and the key generation process should be restarted with an alternate
+        guardian. If, however, the published Pi (ℓ) and Ri,ℓ satisfy both the published encryption and the
+        equation above, the claim of malfeasance is dismissed, and the key generation process continues
+        undeterred.19
+
+        But in discussions with Josh 11/9/22, he says:
+
+        As, I’m seeing things, the nonces aren’t relevant and never need to be supplied.  Guardian  is supposed to send
+        Guardian  the share value  by encrypting it as  and handing it off.  If Guardian  claims to have not received a
+        satisfactory , Guardian  is supposed to simply publish  so that anyone can check its validity directly.
+        The verification is against the previously committed versions of coefficients  instead of against the
+        transmitted encryption.  This prevents observers from needing to adjudicate whether or not Guardian
+        sent a correct value initially.
+
+        So im disabling the nonce exchange, and wait for spec 2 before continuing this.
+         */
+
         /*
         val encryptedKeyShare = myShareOfOthers[keyShare.missingGuardianId] // what they sent us before
         if (encryptedKeyShare == null) {

--- a/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyDecryption.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyDecryption.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.*
 import electionguard.ballot.Manifest
 import electionguard.ballot.DecryptedTallyOrBallot
 import electionguard.core.*
+import electionguard.core.Base16.toHex
 import kotlin.collections.mutableSetOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -125,12 +126,12 @@ class VerifyDecryption(
         if (!proof.r.inBounds()) {
             results.add(Err("     (10.A,14.A) The value v is not in the set Zq.: '$where'"))
         }
-        //(10.B,14.B) The challenge value c satisfies c = H(Q, K, C0, C1, C2, a, b, β).
+        // (10.B,14.B) The challenge value c satisfies c = H(Q, K, C0, C1, C2, a, b, β).
         val challenge = hashElements(
             qbar,
             jointPublicKey,
             ciphertext.c0,
-            // ciphertext.c1, LOOK how to hash a byte array?
+            ciphertext.c1.toHex(),
             ciphertext.c2,
             a,
             b,

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTrusteeTest.kt
@@ -208,18 +208,18 @@ class KeyCeremonyTrusteeTest {
         assertTrue(resultBadId is Err)
         assertTrue(resultBadId.error.contains("Trustee 'id2', does not have public key for missingGuardianId 'badId'"))
 
-        /* Give it a bad nonce LOOK this is disabled in receiveKeyShare()
-        val keyShareBadNonce = keyShare12.copy(nonce = group.TWO_MOD_Q)
-        val resultBadNonce = trustee2.receiveKeyShare(keyShareBadNonce)
-        assertTrue(resultBadNonce is Err)
-        assertEquals("Trustee 'id2' couldnt decrypt encryptedKeyShare for missingGuardianId 'id1'", resultBadNonce.error)
-         */
-
         // Give it a bad coordinate
         val keyShareBadCoordinate = keyShare12.copy(coordinate = group.TWO_MOD_Q)
         val resultBadCoordinate = trustee2.receiveKeyShare(keyShareBadCoordinate)
         assertTrue(resultBadCoordinate is Err)
         println("result = $resultBadCoordinate")
         assertTrue(resultBadCoordinate.error.contains("Trustee 'id2' failed to validate KeyShare for missingGuardianId 'id1'"))
+
+        /* Give it a bad nonce LOOK this is disabled in KeyCeremonyTrustee.receiveKeyShare(), see notes there
+        val keyShareBadNonce = keyShare12.copy(nonce = group.TWO_MOD_Q)
+        val resultBadNonce = trustee2.receiveKeyShare(keyShareBadNonce)
+        assertTrue(resultBadNonce is Err)
+        assertEquals("Trustee 'id2' couldnt decrypt encryptedKeyShare for missingGuardianId 'id1'", resultBadNonce.error)
+         */
     }
 }


### PR DESCRIPTION
Clarify disabling using the nonce to decrypt the El(Pi(ℓ)), in KeyCeremonyTrustee.receiveKeyShare().