### PR TITLE
Put all uses of Sinks in try/finally or use block.

### DIFF
--- a/egklib/src/commonMain/kotlin/electionguard/publish/Publisher.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/publish/Publisher.kt
@@ -2,6 +2,7 @@ package electionguard.publish
 
 import electionguard.ballot.*
 import electionguard.keyceremony.KeyCeremonyTrustee
+import io.ktor.utils.io.core.Closeable
 
 /** Write the Election Record as protobuf or json files. */
 interface Publisher {
@@ -19,14 +20,12 @@ interface Publisher {
     fun writeTrustee(trusteeDir: String, trustee: KeyCeremonyTrustee)
 }
 
-interface EncryptedBallotSinkIF {
+interface EncryptedBallotSinkIF : Closeable {
     fun writeEncryptedBallot(ballot: EncryptedBallot)
-    fun close()
 }
 
-interface DecryptedTallyOrBallotSinkIF {
+interface DecryptedTallyOrBallotSinkIF : Closeable {
     fun writeDecryptedTallyOrBallot(tally: DecryptedTallyOrBallot)
-    fun close()
 }
 
 fun makePublisher(

--- a/egklib/src/commonMain/kotlin/electionguard/publish/RunElectionRecordConvert.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/publish/RunElectionRecordConvert.kt
@@ -2,6 +2,7 @@ package electionguard.publish
 
 import electionguard.core.GroupContext
 import electionguard.core.productionGroup
+import io.ktor.utils.io.core.use
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.required
@@ -48,11 +49,12 @@ fun runElectionRecordConvert(group: GroupContext, inputDir: String, outputDir: S
         println(" electionInit written")
     }
 
-    val esink = producer.encryptedBallotSink()
     var ecount = 0
-    consumer.iterateEncryptedBallots{ true} .forEach() {
-        esink.writeEncryptedBallot(it)
-        ecount++
+    producer.encryptedBallotSink().use { esink ->
+        consumer.iterateEncryptedBallots { true }.forEach() {
+            esink.writeEncryptedBallot(it)
+            ecount++
+        }
     }
     println(" $ecount encryptedBallots written")
 
@@ -68,11 +70,12 @@ fun runElectionRecordConvert(group: GroupContext, inputDir: String, outputDir: S
         println(" decrypted tally result written")
     }
 
-    val dsink = producer.decryptedTallyOrBallotSink()
     var dcount = 0
-    consumer.iterateDecryptedBallots().forEach() {
-        dsink.writeDecryptedTallyOrBallot(it)
-        dcount++
+    producer.decryptedTallyOrBallotSink().use { dsink ->
+        consumer.iterateDecryptedBallots().forEach() {
+            dsink.writeDecryptedTallyOrBallot(it)
+            dcount++
+        }
     }
     println(" $dcount decryptedBallots written")
 }

--- a/egklib/src/commonTest/kotlin/electionguard/publish/PublisherJsonTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/publish/PublisherJsonTest.kt
@@ -10,6 +10,7 @@ import electionguard.protoconvert.generateElectionConfig
 import electionguard.protoconvert.generateElementModP
 import electionguard.protoconvert.generateGuardian
 import electionguard.protoconvert.generateUInt256
+import io.ktor.utils.io.core.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -116,11 +117,11 @@ class PublisherJsonTest {
         val publisher = makePublisher(output4, true, true)
         val consumerOut = makeConsumer(output4, group, true)
 
-        val sink: DecryptedTallyOrBallotSinkIF = publisher.decryptedTallyOrBallotSink()
-        consumerIn.iterateDecryptedBallots().forEach {
-            sink.writeDecryptedTallyOrBallot(it)
-        }
-        sink.close()
+       publisher.decryptedTallyOrBallotSink().use { sink ->
+           consumerIn.iterateDecryptedBallots().forEach {
+               sink.writeDecryptedTallyOrBallot(it)
+           }
+       }
 
         assertTrue(consumerOut.iterateDecryptedBallots().approxEqualsDecryptedBallots(consumerIn.iterateDecryptedBallots()))
     }

--- a/egklib/src/commonTest/kotlin/electionguard/publish/PublisherProtoTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/publish/PublisherProtoTest.kt
@@ -9,6 +9,7 @@ import electionguard.protoconvert.generateElectionConfig
 import electionguard.protoconvert.generateElementModP
 import electionguard.protoconvert.generateGuardian
 import electionguard.protoconvert.generateUInt256
+import io.ktor.utils.io.core.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -106,11 +107,11 @@ class PublisherProtoTest {
 
     @Test
     fun testWriteSpoiledBallots() {
-        val sink: DecryptedTallyOrBallotSinkIF = publisher.decryptedTallyOrBallotSink()
-        consumerIn.iterateDecryptedBallots().forEach {
-            sink.writeDecryptedTallyOrBallot(it)
+        publisher.decryptedTallyOrBallotSink().use { sink ->
+            consumerIn.iterateDecryptedBallots().forEach {
+                sink.writeDecryptedTallyOrBallot(it)
+            }
         }
-        sink.close()
 
         val inBallots = consumerIn.iterateDecryptedBallots().associateBy { it.id }
         consumerOut.iterateDecryptedBallots().forEach {

--- a/egklib/src/jvmMain/kotlin/electionguard/publish/PublisherJson.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/publish/PublisherJson.kt
@@ -68,9 +68,9 @@ actual class PublisherJson actual constructor(topDir: String, createNew: Boolean
         writeElectionInitialized(init)
 
         validateOutputDir(Path.of(jsonPaths.encryptedBallotDir()), Formatter())
-        val sink = encryptedBallotSink()
-        ballots.forEach {sink.writeEncryptedBallot(it) }
-        sink.close()
+        encryptedBallotSink().use { sink ->
+            ballots.forEach { sink.writeEncryptedBallot(it) }
+        }
     }
 
     actual override fun writeTallyResult(tally: TallyResult) {

--- a/egklib/src/jvmMain/kotlin/electionguard/publish/PublisherProto.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/publish/PublisherProto.kt
@@ -100,9 +100,9 @@ actual class PublisherProto actual constructor(topDir: String, createNew: Boolea
         ballots: Iterable<EncryptedBallot>
     ) {
         writeElectionInitialized(init)
-        val sink = encryptedBallotSink()
-        ballots.forEach {sink.writeEncryptedBallot(it) }
-        sink.close()
+        encryptedBallotSink().use { sink ->
+            ballots.forEach { sink.writeEncryptedBallot(it) }
+        }
     }
 
     actual override fun writeTallyResult(tally: TallyResult) {


### PR DESCRIPTION
EncryptedBallotSinkIF, DecryptedTallyOrBallotSinkIF extend Closeable. 
Revert native fread/fwrite changes.
Fixes failing native test: RunElectionRecordConvertTest