### PR TITLE
Use absolute path for native loader to fix link failure..

### DIFF
--- a/egklib/build.gradle.kts
+++ b/egklib/build.gradle.kts
@@ -59,17 +59,17 @@ kotlin {
             else -> throw GradleException("Host OS is not supported.")
         }
 
+    /*
     nativeTarget.apply {
         binaries {
-            executable("RunBatchEncryption") {
-                entryPoint = "electionguard.encrypt.main"
-            }
             sharedLib() {
                 baseName = "ekm" // on Linux and macOS
                 // baseName = "libekm // on Windows
             }
         }
     }
+
+     */
 
     sourceSets {
         all { languageSettings.optIn("kotlin.RequiresOptIn") }

--- a/egklib/src/commonMain/kotlin/electionguard/core/Primes3072.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Primes3072.kt
@@ -5,6 +5,7 @@ import electionguard.core.Base16.fromHex
 // copied from the ElectionGuard 1.9 spec, Appendix "Other Parameters"
 object Primes3072 {
     val nbits = 3072
+    val nbytes = nbits/8
 
     private val pOrg =
         "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
@@ -21,7 +22,7 @@ object Primes3072 {
                 "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF"
 
     val pStr = pOrg.filterNot { it.isWhitespace() }
-    val largePrimeBytes = pStr.fromHex()!!.normalize(512)
+    val largePrimeBytes = pStr.fromHex()!!.normalize(nbytes)
 
     val qStr = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43"
     val smallPrimeBytes = qStr.fromHex()!!.normalize(32)
@@ -40,7 +41,7 @@ object Primes3072 {
                 "9FD4A7F5 29FD4A7F 529FD4A7 F529FD4A 7F529FD4 A7F529FD 4A7F529F D4A7F52A"
 
     val rStr = rOrg.filterNot { it.isWhitespace() }
-    val residualBytes = rStr.fromHex()!!.normalize(512)
+    val residualBytes = rStr.fromHex()!!.normalize(nbytes)
 
     private val gOrg =
         "4A1523CB 0111B381 04EBCDE5 163F581E EEDD9163 7AC57544 C1D22832 34272732" +
@@ -57,6 +58,5 @@ object Primes3072 {
                 "EC0BF615 A1FA74BC 727014CF AC40E20E A194489F 63A6C224 27CB999C 9D04AA61"
 
     val gStr = gOrg.filterNot { it.isWhitespace() }
-    val generatorBytes = gStr.fromHex()!!.normalize(512)
-
+    val generatorBytes = gStr.fromHex()!!.normalize(nbytes)
 }

--- a/egklib/src/commonMain/kotlin/electionguard/core/Primes4096.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Primes4096.kt
@@ -5,6 +5,7 @@ import electionguard.core.Base16.fromHex
 // copied from the ElectionGuard 1.9 spec 3.1.1
 object Primes4096 {
     val nbits = 4096
+    val nbytes = nbits/8
 
     private val pOrg =
         "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF" +
@@ -25,7 +26,7 @@ object Primes4096 {
                 "FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF"
 
      val pStr = pOrg.filterNot { it.isWhitespace() }
-     val largePrimeBytes = pStr.fromHex()!!.normalize(512)
+     val largePrimeBytes = pStr.fromHex()!!.normalize(nbytes)
 
     val qStr = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43"
     val smallPrimeBytes = qStr.fromHex()!!.normalize(32)
@@ -49,7 +50,7 @@ object Primes4096 {
 
     val rStr = rOrg.filterNot { it.isWhitespace() }
     val residualNotNormalized = rStr.fromHex()!!
-    val residualBytes = rStr.fromHex()!!.normalize(512)
+    val residualBytes = rStr.fromHex()!!.normalize(nbytes)
 
     private val gOrg =
         "36036FED 214F3B50 DC566D3A 312FE413 1FEE1C2B CE6D02EA 39B477AC 05F7F885" +
@@ -70,5 +71,5 @@ object Primes4096 {
                 "E7EBA151 BA486094 D68722B0 54633FEC 51CA3F29 B31E77E3 17B178B6 B9D8AE0F"
 
     val gStr = gOrg.filterNot { it.isWhitespace() }
-    val generatorBytes = gStr.fromHex()!!.normalize(512)
+    val generatorBytes = gStr.fromHex()!!.normalize(nbytes)
 }

--- a/egklib/src/commonMain/kotlin/electionguard/core/UInt256.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/UInt256.kt
@@ -59,7 +59,7 @@ fun ByteArray.normalize(want: Int): ByteArray {
         val leading = size - want
         for (idx in 0 until leading) {
             if (this[idx].compareTo(0) != 0) {
-                throw IllegalArgumentException("Input has $size bytes; UInt256 only supports 32")
+                throw IllegalArgumentException("ByteArray.normalize has $size bytes, only want $want, leading zeroes stop at $idx")
             }
         }
         this.copyOfRange(leading, this.size)
@@ -68,7 +68,6 @@ fun ByteArray.normalize(want: Int): ByteArray {
         leftPad + this
     }
 }
-
 
 /**
  * Safely converts a [UInt256] to an [ElementModQ], wrapping values outside the range back to the

--- a/egklib/src/commonTest/kotlin/electionguard/core/HashTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/HashTest.kt
@@ -1,6 +1,7 @@
 package electionguard.core
 
 import electionguard.core.Base16.fromSafeHex
+import electionguard.core.Base16.toHex
 import io.kotest.property.checkAll
 import io.kotest.property.forAll
 import io.ktor.utils.io.core.*
@@ -43,8 +44,8 @@ class HashTest {
             val ballotNonce = "13E7A2F4253E6CCE42ED5576CF7B01A06BE07835227E7AFE5F538FB94E9A9B73".fromSafeHex()
                 .toUInt256().toElementModQ(group)
             val nonceSequence = Nonces(contestDescriptionHashQ, ballotNonce)
-            val nonce0 = nonceSequence[0]
-            println(" nonce seed in hex = ${nonceSequence.internalSeed}")
+            val nonce0: ElementModQ = nonceSequence[0]
+            println(" nonce seed in hex = ${nonceSequence.internalSeed.toHex()}")
             println(" nonce0 in hex = ${nonce0}")
             val expect = "ACDE405F255D4C3101A895AE80863EA4639A889593D557EB5AD5B855684D5B50".fromSafeHex()
                 .toUInt256().toElementModQ(group)

--- a/egklib/src/jvmTest/kotlin/electionguard/core/TestConstants.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/core/TestConstants.kt
@@ -63,4 +63,19 @@ class TestConstants {
         assertEquals(b64TestR, rr)
         assertEquals(b64TestP, pp)
     }
+
+
+    @Test
+    fun p256minusQBase64() {
+        val p256 = BigInteger.valueOf(1) shl 256
+        val q = Primes4096.smallPrimeBytes.toBigInteger()
+        val p256minusQ = (p256 - q).toByteArray()
+        assertEquals(2, p256minusQ.size)
+
+        val p256minusQBase64 = p256minusQ.toBase64()
+        assertEquals(p256minusQBase64, b64Production4096P256MinusQ)
+
+        val p256minusQBytes = b64Production4096P256MinusQ.fromSafeBase64()
+        assertEquals(2, p256minusQBytes.size)
+    }
 }

--- a/egklib/src/nativeTest/kotlin/electionguard/core/TestConstants.kt
+++ b/egklib/src/nativeTest/kotlin/electionguard/core/TestConstants.kt
@@ -47,4 +47,25 @@ class TestConstants {
         assertContentEquals(ig, g, "G")
         assertContentEquals(ir, r, "R")
     }
+
+    @Test
+    fun testProductionGroups4096() {
+        println("testProductionGroups4096")
+        val mode = PowRadixOption.LOW_MEMORY_USE
+        val productionGroups4096 =
+            ProductionGroupContext(
+                pBytes = Primes4096.largePrimeBytes,
+                qBytes = Primes4096.smallPrimeBytes,
+                gBytes = Primes4096.generatorBytes,
+                rBytes = Primes4096.residualBytes,
+                p256minusQBytes = b64Production4096P256MinusQ.fromSafeBase64(),
+                name = "production group, ${mode.description}, 4096 bits",
+                powRadixOption = mode,
+                productionMode = ProductionMode.Mode4096,
+                numPBits = Primes4096.nbits.toUInt(),
+                numPBytes = Primes4096.nbits.toUInt() / 8U,
+                numPLWords = Primes4096.nbits.toUInt() / 64U,
+            )
+    }
+
 }

--- a/hacllib/nativeInterop/libhacl.def
+++ b/hacllib/nativeInterop/libhacl.def
@@ -14,7 +14,7 @@ staticLibraries = libhacl.a
 libraryPaths = build
 
 linkerOpts.osx = --library hacl --library-path hacllib/build
-linkerOpts.linux = --library hacl --library-path hacllib/build
+linkerOpts.linux = --library hacl --library-path /home/stormy/dev/github/electionguard-kotlin-multiplatform/hacllib/build/
 
 compilerOpts.osx = -Ilibhacl/include
 compilerOpts.linux = -Ilibhacl/include -O2


### PR DESCRIPTION
Fix Primes3072 normalize size.
Remove nativeTarget binary building for now.