### PR TITLE
spec 2.0 hashing, KeyCeremony

### DIFF
--- a/egklib/src/commonMain/kotlin/electionguard/ballot/ElectionConfig.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/ballot/ElectionConfig.kt
@@ -143,6 +143,7 @@ fun manifestHash(Hp: UInt256, manifestBytes : ByteArray) : UInt256 {
     return hashFunction(
         Hp.bytes,
         0x01.toByte(),
+        manifestBytes.size, // b(len(file), 4) ∥ b(file, len(file)) , section 5.1.5
         manifestBytes,
     )
 }
@@ -153,8 +154,8 @@ fun electionBaseHash(Hp: UInt256, HM: UInt256, n : Int, k : Int) : UInt256 {
         Hp.bytes,
         0x02.toByte(),
         HM.bytes,
-        n.toUShort(),
-        k.toUShort(),
+        n,
+        k,
     )
 }
 

--- a/egklib/src/commonMain/kotlin/electionguard/core/ElGamal.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/ElGamal.kt
@@ -108,7 +108,7 @@ data class ElGamalCiphertext(val pad: ElementModP, val data: ElementModP) {
  * @throws ArithmeticException if the secret key is less than two
  */
 fun elGamalKeyPairFromSecret(secret: ElementModQ) =
-    ElGamalKeypair(ElGamalSecretKey(secret), ElGamalPublicKey(secret.context.gPowP(secret)))
+    ElGamalKeypair(ElGamalSecretKey(secret), ElGamalPublicKey(secret.context.gPowP(secret))) // eq 10
 
 /** Generates a random ElGamal keypair. */
 fun elGamalKeyPairFromRandom(context: GroupContext) =

--- a/egklib/src/commonMain/kotlin/electionguard/core/Hash.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Hash.kt
@@ -34,6 +34,7 @@ fun hashFunction(key: ByteArray, vararg elements: Any): UInt256 {
 }
 
 // identical to hashFunction, made separate to follow the spec.
+// only called from KeyCeremonyTrustee. doesnt use strings
 fun hmacFunction(key: ByteArray, vararg elements: Any): UInt256 {
     require(elements.size > 0)
     val hmac = HmacSha256(key)
@@ -50,7 +51,7 @@ private fun HmacSha256.addToHash(element : Any) {
             is ByteArray -> element
             is UInt256 -> element.bytes
             is Element -> element.byteArray()
-            is String -> element.toByteArray()
+            is String -> element.toByteArray() // LOOK not adding size
             // is Short -> ByteArray(2) { if (it == 0) (element / 256).toByte() else (element % 256).toByte() }
             // is UShort -> ByteArray(2) { if (it == 0) (element / U256).toByte() else (element % U256).toByte() }
             is Int -> intToByteArray(element)

--- a/egklib/src/commonMain/kotlin/electionguard/core/HashedElGamal.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/HashedElGamal.kt
@@ -7,7 +7,7 @@ data class HashedElGamalCiphertext(
     val c0: ElementModP,
     val c1: ByteArray,
     val c2: UInt256,
-    val numBytes: Int
+    val numBytes: Int // TODO not sure if this is needed
 ) {
     // override because of the ByteArray
     override fun equals(other: Any?): Boolean {

--- a/egklib/src/commonMain/kotlin/electionguard/core/Schnorr.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Schnorr.kt
@@ -47,7 +47,7 @@ data class SchnorrProof(
 }
 
 /**
- * Given an ElGamal keypair (public and private key), generate a ZNP (zero knowledge proof)
+ * Given an ElGamal keypair (public and private key) for i,j, generate a ZNP (zero knowledge proof)
  * that the author of the proof knows the private key, without revealing it.
  */
 fun ElGamalKeypair.schnorrProof(
@@ -55,11 +55,10 @@ fun ElGamalKeypair.schnorrProof(
     coeff: Int, // j
     nonce: ElementModQ = context.randomElementModQ() // u_ij
 ): SchnorrProof {
-    // spec 2.0.0, eq 12
     val context = compatibleContextOrFail(publicKey.key, secretKey.key, nonce)
-    val h = context.gPowP(nonce) // eq 10
-    val c = hashFunction(context.constants.hp.bytes, 0x10.toByte(), guardianXCoord, coeff, publicKey.key, h).toElementModQ(context) // eq 11
-    val v = nonce - secretKey.key * c // response
+    val h = context.gPowP(nonce) //spec 2.0.0,  eq 11
+    val c = hashFunction(context.constants.hp.bytes, 0x10.toByte(), guardianXCoord, coeff, publicKey.key, h).toElementModQ(context) // eq 12
+    val v = nonce - secretKey.key * c // response value vi,j = (ui,j − ci,j * ai,j ) mod q
 
     return SchnorrProof(publicKey.key, c, v)
 }

--- a/egklib/src/commonMain/kotlin/electionguard/core/Schnorr.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Schnorr.kt
@@ -55,10 +55,10 @@ fun ElGamalKeypair.schnorrProof(
     coeff: Int, // j
     nonce: ElementModQ = context.randomElementModQ() // u_ij
 ): SchnorrProof {
-    // spec 1.9, p 19
+    // spec 2.0.0, eq 12
     val context = compatibleContextOrFail(publicKey.key, secretKey.key, nonce)
     val h = context.gPowP(nonce) // eq 10
-    val c = hashFunction(context.constants.hp.bytes, 0x10.toByte(), guardianXCoord.toUShort(), coeff.toUShort(), publicKey.key, h).toElementModQ(context) // eq 11
+    val c = hashFunction(context.constants.hp.bytes, 0x10.toByte(), guardianXCoord, coeff, publicKey.key, h).toElementModQ(context) // eq 11
     val v = nonce - secretKey.key * c // response
 
     return SchnorrProof(publicKey.key, c, v)

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/ElectionPolynomial.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/ElectionPolynomial.kt
@@ -2,7 +2,7 @@ package electionguard.keyceremony
 
 import electionguard.core.*
 
-/** Pi(x), spec 1.9, section 3.2.1. Must be kept secret. */
+/** Pi(x), spec 2.0.0, section 3.2.1. Must be kept secret. */
 data class ElectionPolynomial(
     val guardianId: String,  // ith guardian
 
@@ -28,6 +28,7 @@ data class ElectionPolynomial(
         var result: ElementModQ = group.ZERO_MOD_Q
         var xcoordPower: ElementModQ = group.ONE_MOD_Q
 
+        // spec 2.0.0, p 22, eq 9
         for (coefficient in this.coefficients) {
             val term = coefficient * xcoordPower
             result += term
@@ -40,7 +41,7 @@ data class ElectionPolynomial(
 /**
  * Calculate g^Pi(xcoord) mod p = Product ((K_i,j)^xcoord^j) mod p, j = 0, quorum-1.
  * Used to test secret key share by KeyCeremonyTrustee, and verifying results in TallyDecryptor.
- * spec 1.9, sec 3.2.2 eq 19:
+ * spec 2.0.0, sec 3.2.2, p 24, eq 21:
  */
 fun calculateGexpPiAtL(
     xcoord: Int,  // evaluated at xcoord ℓ
@@ -59,7 +60,7 @@ fun calculateGexpPiAtL(
     return result
 }
 
-/** Generate random coefficients for a polynomial of degree quorum-1. spec 1.9, p 19, eq 8 and 9. */
+/** Generate random coefficients for a polynomial of degree quorum-1. spec 2.0.0, p 22, eq 9 and 10. */
 fun GroupContext.generatePolynomial(
     guardianId: String,
     guardianXCoord: Int,
@@ -78,6 +79,7 @@ fun GroupContext.generatePolynomial(
     return ElectionPolynomial(guardianId, coefficients, commitments, proofs)
 }
 
+// possibly only used in testing?
 fun GroupContext.regeneratePolynomial(
     guardianId: String,
     guardianXCoord: Int,

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
@@ -85,18 +85,18 @@ fun keyCeremonyExchange(trustees: List<KeyCeremonyTrusteeIF>, allowEncryptedFail
         }
     }
 
-    // spec 1.9, p 21
+    // spec 2.0.0, p 24 "Share verification"
     // If the recipient guardian Gℓ reports not receiving a suitable value Pi (ℓ), it becomes incumbent on the
     // sending guardian Gi to publish this Pi (ℓ) together with the nonce ξi,ℓ it used to encrypt Pi (ℓ)
     // under the public key Kℓ of recipient guardian Gℓ . If guardian Gi fails to produce a suitable Pi (ℓ)
     // and nonce ξi,ℓ that match both the published encryption and the above equation, it should be
-    // excluded from the election and the key generation process should be restarted with an alternate guardian.
-    //   If, however, the published Pi (ℓ) and ξi,ℓ satisfy both the published encryption and the
-    // equation (19) above, the claim of malfeasance is dismissed, and the key generation process continues undeterred.
-    //   It is also permissible to dismiss any guardian that makes a false claim of malfeasance. However, this is not
-    // required as the sensitive information that is released as a result of the claim could have been released by the
-    // claimant in any case.
-    // TODO should KeyShare include ξi,ℓ
+    // excluded from the election and the key generation process should be restarted with an alternate
+    // guardian. If, however, the published Pi (ℓ) and ξi,ℓ satisfy both the published encryption and the
+    // equation above, the claim of malfeasance is dismissed, and the key generation process continues undeterred.
+    // footnote 28 It is also permissible to dismiss any guardian that makes a false claim of malfeasance. However, this is not
+    // required as the sensitive information that is released as a result of the claim could have been released by the claimant
+    // in any case.
+    // TODO KeyShare should include ξi,ℓ
 
     // Phase Two: if any secretKeyShares fail to validate, send and validate KeyShares
     val keyResults: MutableList<Result<Boolean, String>> = mutableListOf()
@@ -145,13 +145,12 @@ data class KeyCeremonyResults(
         config: ElectionConfig,
         metadata: Map<String, String> = emptyMap(),
     ): ElectionInitialized {
+        // spec 2.0.0 p.25, eq 8.
         val jointPublicKey: ElementModP =
             publicKeysSorted.map { it.publicKey().key }.reduce { a, b -> a * b }
 
-        // He = H(HB ; 12, K, K1,0 , K1,1 , . . . , K1,k−1 , K2,0 , . . . , Kn,k−2 , Kn,k−1 ) spec 1.9 p.22, eq 20.
-        val commitments: MutableList<ElementModP> = mutableListOf()
-        publicKeysSorted.forEach { commitments.addAll(it.coefficientCommitments()) }
-        val extendedBaseHash = hashFunction(config.electionBaseHash.bytes, 0x12.toByte(), jointPublicKey, commitments)
+        // He = H(HB ; 0x12, K) ; spec 2.0.0 p.25, eq 23.
+        val extendedBaseHash = hashFunction(config.electionBaseHash.bytes, 0x12.toByte(), jointPublicKey)
 
         val guardians: List<Guardian> = publicKeysSorted.map { makeGuardian(it) }
 

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
@@ -199,47 +199,51 @@ open class KeyCeremonyTrustee(
 
         val K_l = other.publicKey() // other's publicKey
         val hp = K_l.context.constants.hp.bytes
-        val i = xCoordinate.toUShort()
-        val l = other.guardianXCoordinate.toUShort()
+        val i = xCoordinate
+        val l = other.guardianXCoordinate
 
-        // (alpha, beta) = (g^R mod p, K^R mod p)  spec 2.0.0, eq 14
+        // (αi,ℓ , βi,ℓ ) = (g^ξi,ℓ mod p, K^ξi,ℓ mod p), ξi,ℓ = nonce
+        // (α_i,ℓ , β_i,ℓ ) = (g^nonce mod p, Kℓ^nonce mod p) ;  spec 2.0.0, eq 14
         // by encrypting a zero, we achieve exactly this
         val (alpha, beta) = 0.encrypt(K_l, nonce)
-        // ki,ℓ = H(HP ; 11, i, ℓ, Kℓ , αi,ℓ , βi,ℓ ) spec 2.0.0, eq 15
+        // ki,ℓ = H(HP ; 0x11, i, ℓ, Kℓ , αi,ℓ , βi,ℓ ) ; eq 15 "secret key"
         val kil = hashFunction(hp, 0x11.toByte(), i, l, K_l.key, alpha, beta).bytes
 
         // footnote 27
         // This key derivation uses the KDF in counter mode from SP 800-108r1. The second input to HMAC contains
-        // the counter in the first byte, the UTF-8 encoding of the string "share enc keys" as the Label (encoding is denoted
-        // by b(. . . ), see Section 5.1.4), a separation 00 byte, the UTF-8 encoding of the string "share encrypt" concatenated
+        // the counter in the first byte, the UTF-8 encoding of the string "share_enc_keys" as the Label (encoding is denoted
+        // by b(. . . ), see Section 5.1.4), a separation 00 byte, the UTF-8 encoding of the string "share_encrypt" concatenated
         // with encodings of the numbers i and ℓ of the sending and receiving guardians as the Context, and the final two bytes
         // specifying the length of the output key material as 512 bits in total.
 
-        // context = b(”share encrypt”) ∥ b(i, 2) ∥ b(ℓ, 2)
-        // k0 = HMAC(ki,ℓ , 01 ∥ label ∥ 00 ∥ context ∥ 0200) spec 2.0.0,  eq 16
-        val k0 = hmacFunction(kil, 0x01.toByte(), label, 0x00.toByte(), context, i, l, 512.toShort()).bytes
-        // k1 = HMAC(ki,ℓ , 02 ∥ label ∥ 00 ∥ context ∥ 0200), spec 2.0.0, eq 17
-        val k1 = hmacFunction(kil, 0x02.toByte(), label, 0x00.toByte(), context, i, l, 512.toShort()).bytes
+        // Label = b(“share enc keys”, 14)
+        // Context = b(“share_encrypt”, 13) ∥ b(i, 4) ∥ b(ℓ, 4)
+        // k0 = HMAC(ki,ℓ , 0x01 ∥ Label ∥ 0x00 ∥ Context ∥ 0x0200) ; spec 2.0.0,  eq 16
+        val k0 = hmacFunction(kil, 0x01.toByte(), label, 0x00.toByte(), context, i, l, 512).bytes
+        // k1 = HMAC(ki,ℓ , 0x02 ∥ Label ∥ 0x00 ∥ Context ∥ 0x0200) ; eq 17
+        val k1 = hmacFunction(kil, 0x02.toByte(), label, 0x00.toByte(), context, i, l, 512).bytes
 
         // spec 2.0.0, eq 19
-        // C0 = g^nonce == alpha
+        // Ci,ℓ,0 = g^ξi,ℓ mod p = C0 = g^nonce == alpha
         val c0: ElementModP = alpha
-        // C1 = b(Pi(ℓ),32) ⊕ k1, • The symbol ⊕ denotes bitwise XOR.
+        // C1 = b(Pi(ℓ),32) ⊕ k1, where the symbol ⊕ denotes bitwise XOR.
         val pilBytes = Pil.byteArray()
         val c1 = ByteArray(32) { pilBytes[it] xor k1[it] }
-        // C2 = HMAC(k0 , b(Ci,ℓ,0 , 512) ∥ Ci,ℓ,1 )
+        // Ci,ℓ,2 = HMAC(k0 , b(Ci,ℓ,0 , 512) ∥ Ci,ℓ,1 )
+        // C2 = HMAC(k0, b(C0,512) ∥ C1 )
         val c2 = hmacFunction(k0, c0, c1)
 
         return HashedElGamalCiphertext(c0, c1, c2, pilBytes.size)
     }
 
-    // Share decryption. After receiving the ciphertext (Ci,ℓ,0 , Ci,ℓ,1 , Ci,ℓ,2 ) from guardian Gi , guardian
-    // Gℓ decrypts it by computing βi,ℓ = (Ci,ℓ,0 )sℓ mod p, setting αi,ℓ = Ci,ℓ,0 and obtaining
+    // Share decryption.
+    // After receiving the ciphertext (Ci,ℓ,0 , Ci,ℓ,1 , Ci,ℓ,2 ) from guardian Gi , guardian
+    // Gℓ decrypts it by computing βi,ℓ = (Ci,ℓ,0)^sℓ mod p, setting αi,ℓ = Ci,ℓ,0 and obtaining
     //   ki,ℓ = H(HP ; 11, i, ℓ, Kℓ , αi,ℓ , βi,ℓ ).
     // Now the MAC key k0 and the encryption key k1 can be computed as
     // above in Equations (16) and (17), which allows Gℓ to verify the validity of the MAC, namely that
     //   Ci,ℓ,2 = HMAC(k0 , b(Ci,ℓ,0 , 512) ∥ Ci,ℓ,1 ).
-    // If the MAC verifies, then Gℓ decrypts b(Pi (ℓ), 32) = Ci,ℓ,1 ⊕k1 .
+    // If the MAC verifies, then Gℓ decrypts b(Pi (ℓ), 32) = Ci,ℓ,1 ⊕ k1 .
     fun shareDecryption(share: EncryptedKeyShare): ByteArray?  {
         // αi,ℓ = Ci,ℓ,0
         // βi,ℓ = (Ci,ℓ,0 )sℓ mod p
@@ -250,23 +254,19 @@ open class KeyCeremonyTrustee(
         val alpha = c0
         val beta = c0 powP this.electionPrivateKey()
         val hp = group.constants.hp.bytes
-        val kil = hashFunction(hp, 0x11.toByte(), share.ownerXcoord.toShort(), xCoordinate.toShort(), electionPublicKey(), alpha, beta).bytes
+        val kil = hashFunction(hp, 0x11.toByte(), share.ownerXcoord, xCoordinate, electionPublicKey(), alpha, beta).bytes
 
         // Now the MAC key k0 and the encryption key k1 can be computed as above in Equations (16) and (17)
-        // context = b(”share encrypt”) ∥ b(i, 2) ∥ b(ℓ, 2)
-        // k0 = HMAC(ki,ℓ , 01 ∥ label ∥ 00 ∥ context ∥ 0200) eq 15
-        val k0 = hmacFunction(kil, 0x01.toByte(), label, 0x00.toByte(), context, share.ownerXcoord.toShort(), xCoordinate.toShort(), 512.toShort()).bytes
-        // k1 = HMAC(ki,ℓ , 02 ∥ label ∥ 00 ∥ context ∥ 0200), eq 16
-        val k1 = hmacFunction(kil, 0x02.toByte(), label, 0x00.toByte(), context, share.ownerXcoord.toShort(), xCoordinate.toShort(), 512.toShort()).bytes
+        val k0 = hmacFunction(kil, 0x01.toByte(), label, 0x00.toByte(), context, share.ownerXcoord, xCoordinate, 512).bytes
+        val k1 = hmacFunction(kil, 0x02.toByte(), label, 0x00.toByte(), context, share.ownerXcoord, xCoordinate, 512).bytes
 
-        // Gℓ can verify the validity of the MAC, namely that
-        // Ci,ℓ,2 = HMAC(k0 , b(Ci,ℓ,0 , 512) ∥ Ci,ℓ,1 ). If the MAC verifies, Gℓ decrypts b(Pi (ℓ), 32) = Ci,ℓ,1 ⊕ k1 .
+        // Gℓ can verify the validity of the MAC, namely that Ci,ℓ,2 = HMAC(k0 , b(Ci,ℓ,0 , 512) ∥ Ci,ℓ,1 ).
         val expectedC2 = hmacFunction(k0, c0, c1)
         if (expectedC2 != share.encryptedCoordinate.c2) {
             return null
         }
 
-        //  If the MAC verifies, Gℓ decrypts b(Pi (ℓ), 32) = Ci,ℓ,1 ⊕ k1 .
+        //  If the MAC verifies, Gℓ decrypts b(Pi(ℓ), 32) = Ci,ℓ,1 ⊕ k1 .
         val pilBytes = ByteArray(32) { c1[it] xor k1[it] }
         return pilBytes
     }

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremonyTrustee.kt
@@ -51,8 +51,8 @@ open class KeyCeremonyTrustee(
         ))
     }
 
-    // The value P(i) == Gi’s share of the secret key s = (s1 + s2 + · · · + sn )
-    // == (P1 (ℓ) + P2 (ℓ) + · · · + Pn (ℓ)) mod q. eq 66.
+    // The value P(i) == G_i’s share of the secret key s = (s1 + s2 + · · · + sn )
+    // == (P1 (ℓ) + P2 (ℓ) + · · · + Pn (ℓ)) mod q. spec 2.0.0, eq 65.
     override fun keyShare(): ElementModQ {
         var result: ElementModQ = polynomial.valueAt(group, xCoordinate)
         myShareOfOthers.values.forEach{ result += it.yCoordinate }
@@ -89,7 +89,7 @@ open class KeyCeremonyTrustee(
         return errors.merge()
     }
 
-    /** Create another guardian's share of my key, encrypted. spec 1.9 p 20 Share encryption. */
+    /** Create another guardian's share of my key, encrypted. */
     override fun encryptedKeyShareFor(otherGuardian: String): Result<EncryptedKeyShare, String> {
         var pkeyShare = othersShareOfMyKey[otherGuardian]
         if (pkeyShare == null) {
@@ -98,7 +98,7 @@ open class KeyCeremonyTrustee(
 
             // Compute my polynomial's y value at the other's x coordinate = Pi(ℓ)
             val Pil: ElementModQ = polynomial.valueAt(group, other.guardianXCoordinate)
-            // My encryption of Pil, using the other's public key. spec 1.9, section 3.2.2 eq 17.
+            // My encryption of Pil, using the other's public key. spec 2.0.0, section 3.2.2, p 24, eq 18.
             val EPil : HashedElGamalCiphertext = shareEncryption(Pil, other)
 
             pkeyShare = PrivateKeyShare(this.xCoordinate, this.id, other.guardianId, EPil, Pil)
@@ -129,7 +129,7 @@ open class KeyCeremonyTrustee(
 
         // Having decrypted each Pi (ℓ), guardian Gℓ can now verify its validity against
         // the commitments Ki,0 , Ki,1 , . . . , Ki,k−1 made by Gi to its coefficients by confirming that
-        // g^Pi(ℓ) = Prod{ (Kij)^ℓ^j }, for j=0..k-1 eq 19
+        // g^Pi(ℓ) = Prod{ (Kij)^ℓ^j }, for j=0..k-1 ; spec 2.0.0 eq 21
         if (group.gPowP(expectedPil) != calculateGexpPiAtL(this.xCoordinate, publicKeys.coefficientCommitments())) {
             return Err("Trustee '$id' failed to validate EncryptedKeyShare for missingGuardianId '${share.polynomialOwner}'")
         }
@@ -164,7 +164,7 @@ open class KeyCeremonyTrustee(
         if (otherKeys == null) {
             errors.add(Err("Trustee '$id', does not have public key for missingGuardianId '${keyShare.polynomialOwner}'"))
         } else {
-            // check if the Pi(ℓ) that was sent satisfies spec 1.9, eq 12.
+            // check if the Pi(ℓ) that was sent satisfies eq 21.
             // g^Pi(ℓ) = Prod{ (Kij)^ℓ^j }, for j=0..k-1
             if (group.gPowP(keyShare.yCoordinate) != calculateGexpPiAtL(this.xCoordinate, otherKeys.coefficientCommitments())) {
                 errors.add(Err("Trustee '$id' failed to validate KeyShare for missingGuardianId '${keyShare.polynomialOwner}'"))
@@ -190,6 +190,7 @@ open class KeyCeremonyTrustee(
     private val context = "share_encrypt"
 
     // guardian Gi encryption Eℓ of Pi(ℓ) at another guardian's Gℓ coordinate ℓ
+    // see section 3.2.2 "share encryption"
     open fun shareEncryption(
         Pil : ElementModQ,
         other: PublicKeys,
@@ -201,12 +202,13 @@ open class KeyCeremonyTrustee(
         val i = xCoordinate.toUShort()
         val l = other.guardianXCoordinate.toUShort()
 
-        // (alpha, beta) = (g^R mod p, K^R mod p)  spec 1.9, p 20, eq 13
+        // (alpha, beta) = (g^R mod p, K^R mod p)  spec 2.0.0, eq 14
         // by encrypting a zero, we achieve exactly this
         val (alpha, beta) = 0.encrypt(K_l, nonce)
-        // ki,ℓ = H(HP ; 11, i, ℓ, Kℓ , αi,ℓ , βi,ℓ ) eq 14
+        // ki,ℓ = H(HP ; 11, i, ℓ, Kℓ , αi,ℓ , βi,ℓ ) spec 2.0.0, eq 15
         val kil = hashFunction(hp, 0x11.toByte(), i, l, K_l.key, alpha, beta).bytes
 
+        // footnote 27
         // This key derivation uses the KDF in counter mode from SP 800-108r1. The second input to HMAC contains
         // the counter in the first byte, the UTF-8 encoding of the string "share enc keys" as the Label (encoding is denoted
         // by b(. . . ), see Section 5.1.4), a separation 00 byte, the UTF-8 encoding of the string "share encrypt" concatenated
@@ -214,12 +216,12 @@ open class KeyCeremonyTrustee(
         // specifying the length of the output key material as 512 bits in total.
 
         // context = b(”share encrypt”) ∥ b(i, 2) ∥ b(ℓ, 2)
-        // k0 = HMAC(ki,ℓ , 01 ∥ label ∥ 00 ∥ context ∥ 0200) eq 15
+        // k0 = HMAC(ki,ℓ , 01 ∥ label ∥ 00 ∥ context ∥ 0200) spec 2.0.0,  eq 16
         val k0 = hmacFunction(kil, 0x01.toByte(), label, 0x00.toByte(), context, i, l, 512.toShort()).bytes
-        // k1 = HMAC(ki,ℓ , 02 ∥ label ∥ 00 ∥ context ∥ 0200), eq 16
+        // k1 = HMAC(ki,ℓ , 02 ∥ label ∥ 00 ∥ context ∥ 0200), spec 2.0.0, eq 17
         val k1 = hmacFunction(kil, 0x02.toByte(), label, 0x00.toByte(), context, i, l, 512.toShort()).bytes
 
-        // eq 18
+        // spec 2.0.0, eq 19
         // C0 = g^nonce == alpha
         val c0: ElementModP = alpha
         // C1 = b(Pi(ℓ),32) ⊕ k1, • The symbol ⊕ denotes bitwise XOR.
@@ -232,11 +234,12 @@ open class KeyCeremonyTrustee(
     }
 
     // Share decryption. After receiving the ciphertext (Ci,ℓ,0 , Ci,ℓ,1 , Ci,ℓ,2 ) from guardian Gi , guardian
-    // Gℓ decrypts it by computing βi,ℓ = (Ci,ℓ,0 )sℓ mod p, setting αi,ℓ = Ci,ℓ,0 and obtaining ki,ℓ =
-    // H(HP ; 11, i, ℓ, Kℓ , αi,ℓ , βi,ℓ ).
+    // Gℓ decrypts it by computing βi,ℓ = (Ci,ℓ,0 )sℓ mod p, setting αi,ℓ = Ci,ℓ,0 and obtaining
+    //   ki,ℓ = H(HP ; 11, i, ℓ, Kℓ , αi,ℓ , βi,ℓ ).
     // Now the MAC key k0 and the encryption key k1 can be computed as
-    // above in Equations (15) and (16), which allows Gℓ to verify the validity of the MAC, namely that
-    // Ci,ℓ,2 = HMAC(k0 , b(Ci,ℓ,0 , 512) ∥ Ci,ℓ,1 ). If the MAC verifies, Gℓ decrypts b(Pi (ℓ), 32) = Ci,ℓ,1 ⊕k1 .
+    // above in Equations (16) and (17), which allows Gℓ to verify the validity of the MAC, namely that
+    //   Ci,ℓ,2 = HMAC(k0 , b(Ci,ℓ,0 , 512) ∥ Ci,ℓ,1 ).
+    // If the MAC verifies, then Gℓ decrypts b(Pi (ℓ), 32) = Ci,ℓ,1 ⊕k1 .
     fun shareDecryption(share: EncryptedKeyShare): ByteArray?  {
         // αi,ℓ = Ci,ℓ,0
         // βi,ℓ = (Ci,ℓ,0 )sℓ mod p
@@ -249,7 +252,7 @@ open class KeyCeremonyTrustee(
         val hp = group.constants.hp.bytes
         val kil = hashFunction(hp, 0x11.toByte(), share.ownerXcoord.toShort(), xCoordinate.toShort(), electionPublicKey(), alpha, beta).bytes
 
-        // Now the MAC key k0 and the encryption key k1 can be computed as above in Equations (15) and (16)
+        // Now the MAC key k0 and the encryption key k1 can be computed as above in Equations (16) and (17)
         // context = b(”share encrypt”) ∥ b(i, 2) ∥ b(ℓ, 2)
         // k0 = HMAC(ki,ℓ , 01 ∥ label ∥ 00 ∥ context ∥ 0200) eq 15
         val k0 = hmacFunction(kil, 0x01.toByte(), label, 0x00.toByte(), context, share.ownerXcoord.toShort(), xCoordinate.toShort(), 512.toShort()).bytes

--- a/egklib/src/commonMain/kotlin/electionguard/publish/ElectionRecordFactory.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/publish/ElectionRecordFactory.kt
@@ -18,7 +18,7 @@ fun readElectionRecord(consumer: Consumer) : ElectionRecord {
     var tallyResult : TallyResult? = null
     var init : ElectionInitialized? = null
     var config : ElectionConfig? = null
-    var manifest : Manifest?
+    val manifest : Manifest?
     var stage : ElectionRecord.Stage? = null
 
     val decryption = consumer.readDecryptionResult()

--- a/egklib/src/commonTest/kotlin/electionguard/decryptBallot/EncryptDecryptBallotTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/decryptBallot/EncryptDecryptBallotTest.kt
@@ -100,9 +100,7 @@ fun runEncryptDecryptBallot(
 
     //////////////////////////////////////////////////////////
     if (writeout) {
-        val commitments: MutableList<ElementModP> = mutableListOf()
-        trustees.forEach { commitments.addAll(it.coefficientCommitments()) }
-        val extendedBaseHash = hashFunction(config.electionBaseHash.bytes, 0x12.toByte(), jointPublicKey, commitments)
+        val extendedBaseHash = hashFunction(config.electionBaseHash.bytes, 0x12.toByte(), jointPublicKey)
 
         val init = ElectionInitialized(
             config,

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/ShareEncryptDecryptTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/ShareEncryptDecryptTest.kt
@@ -15,6 +15,7 @@ class ShareEncryptDecryptTest {
         runTest {
             val group = productionGroup()
             checkAll(
+                propTestFastConfig,
                 Arb.int(min=1, max=100),
                 elementsModQ(group, minimum = 2)
             ) { xcoord, pil ->

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/DecryptBallotTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/DecryptBallotTestVector.kt
@@ -62,15 +62,13 @@ class DecryptBallotTestVector {
         keyCeremonyExchange(keyCeremonyTrustees)
 
         val publicKeys = mutableListOf<ElementModP>()
-        val allCommitments = mutableListOf<ElementModP>()
         keyCeremonyTrustees.forEach { trustee ->
             publicKeys.add(trustee.electionPublicKey())
-            allCommitments.addAll(trustee.coefficientCommitments())
         }
 
         val electionBaseHash = UInt256.random()
         val publicKey = publicKeys.reduce { a, b -> a * b }
-        val extendedBaseHash = hashFunction(electionBaseHash.bytes, 0x12.toByte(), publicKey, allCommitments)
+        val extendedBaseHash = hashFunction(electionBaseHash.bytes, 0x12.toByte(), publicKey)
 
         val ebuilder = ManifestBuilder("makeDecryptBallotTestVector")
         val manifest: Manifest = ebuilder.addContest("onlyContest")

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/TallyDecryptionTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/TallyDecryptionTestVector.kt
@@ -106,15 +106,13 @@ class TallyDecryptionTestVector(
         keyCeremonyExchange(keyCeremonyTrustees)
 
         val publicKeys = mutableListOf<ElementModP>()
-        val allCommitments = mutableListOf<ElementModP>()
         keyCeremonyTrustees.forEach { trustee ->
             publicKeys.add(trustee.electionPublicKey())
-            allCommitments.addAll(trustee.coefficientCommitments())
         }
 
         val electionBaseHash = UInt256.random()
         val publicKey = publicKeys.reduce { a, b -> a * b }
-        val extendedBaseHash = hashFunction(electionBaseHash.bytes, 0x12.toByte(), publicKey, allCommitments)
+        val extendedBaseHash = hashFunction(electionBaseHash.bytes, 0x12.toByte(), publicKey)
 
         val ebuilder = ManifestBuilder("makeBallotEncryptionTestVector")
         val manifest: Manifest = ebuilder.addContest("onlyContest")


### PR DESCRIPTION
hash integers are 4 bytes
manifest hash: file preceeded by file size
redo intToByteArray() in Hash
extendedBaseHash uses K, not Kij
updated spec references