### PR TITLE
add test output to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *~
 build
 *.hprof
+testOut
+electionguard.log


### PR DESCRIPTION
Without this, the files created by running `./gradlew jvmTest` are considered untracked by `git`.