### PR TITLE
Upgrade for CLI programs.

### DIFF
--- a/egklib/build.gradle.kts
+++ b/egklib/build.gradle.kts
@@ -97,7 +97,7 @@ kotlin {
                     implementation(libs.kotlinx.coroutines.core)
 
                     // Useful, portable routines
-                    implementation(libs.ktor.utils)
+                    // implementation(libs.ktor.utils)
 
                     // Portable logging interface.
                     implementation(libs.microutils.logging)

--- a/egklib/src/commonMain/kotlin/electionguard/ballot/ElectionConfig.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/ballot/ElectionConfig.kt
@@ -2,7 +2,6 @@ package electionguard.ballot
 
 import electionguard.core.*
 import electionguard.core.Base16.toHex
-import io.ktor.utils.io.core.toByteArray
 
 const val protocolVersion = "v2.0.0"
 
@@ -126,7 +125,7 @@ fun parameterBaseHash(primes : ElectionConstants) : UInt256 {
     // The symbol ver denotes the version byte array that encodes the used version of this specification.
     // The array has length 32 and contains the UTF-8 encoding of the string “v2.0.0” followed by 0x00-
     // bytes, i.e. ver = 0x76322E302E30 ∥ b(0, 27). FIX should be b(0, 26)
-    val version = protocolVersion.toByteArray()
+    val version = protocolVersion.encodeToByteArray()
     val HV = ByteArray(32) { if (it < version.size) version[it] else 0 }
 
     return hashFunction(

--- a/egklib/src/commonMain/kotlin/electionguard/cli/RunCreateElectionConfig.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/cli/RunCreateElectionConfig.kt
@@ -5,7 +5,6 @@ import electionguard.ballot.protocolVersion
 import electionguard.core.productionGroup
 import electionguard.publish.makePublisher
 import electionguard.publish.readAndCheckManifestBytes
-import io.ktor.utils.io.core.*
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
@@ -73,7 +72,7 @@ fun createConfig(args: Array<String>) {
             quorum,
             manifestBytes,
             chainCodes,
-            device.toByteArray(),
+            device.encodeToByteArray(),
             mapOf(
                 Pair("CreatedBy", createdBy),
             ),

--- a/egklib/src/commonMain/kotlin/electionguard/core/Hash.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Hash.kt
@@ -1,7 +1,5 @@
 package electionguard.core
 
-import io.ktor.utils.io.core.toByteArray
-
 /**
  * The hash function H used in ElectionGuard is HMAC-SHA-256, i.e. HMAC instantiated with SHA-256.
  * Therefore, H takes two byte arrays as inputs.
@@ -51,7 +49,7 @@ private fun HmacSha256.addToHash(element : Any) {
             is ByteArray -> element
             is UInt256 -> element.bytes
             is Element -> element.byteArray()
-            is String -> element.toByteArray() // LOOK not adding size
+            is String -> element.encodeToByteArray() // LOOK not adding size
             // is Short -> ByteArray(2) { if (it == 0) (element / 256).toByte() else (element % 256).toByte() }
             // is UShort -> ByteArray(2) { if (it == 0) (element / U256).toByte() else (element % U256).toByte() }
             is Int -> intToByteArray(element)
@@ -102,7 +100,7 @@ private fun hashElementsToByteArray(element : Any) : ByteArray {
             is ByteArray -> element
             is UInt256 -> element.bytes
             is Element -> element.byteArray()
-            is String -> element.toByteArray()
+            is String -> element.encodeToByteArray()
             is Short -> ByteArray(2) { if (it == 0) (element / 256).toByte() else (element % 256).toByte() }
             is UShort -> ByteArray(2) { if (it == 0) (element / U256).toByte() else (element % U256).toByte() }
             is Int -> intToByteArray(element)

--- a/egklib/src/commonMain/kotlin/electionguard/core/Utils.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/core/Utils.kt
@@ -2,7 +2,6 @@ package electionguard.core
 
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import com.github.michaelbull.result.*
@@ -137,9 +136,9 @@ inline fun <reified T : Enum<T>> safeEnumValueOf(name: String?): T? {
     }
 }
 
-fun getSystemDate(): LocalDateTime {
+fun getSystemDate(): String {
     val currentMoment: Instant = Clock.System.now()
-    return currentMoment.toLocalDateTime(TimeZone.currentSystemDefault())
+    return currentMoment.toLocalDateTime(TimeZone.currentSystemDefault()).toString()
 }
 
 /**

--- a/egklib/src/commonMain/kotlin/electionguard/decrypt/RunTrustedTallyDecryption.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/decrypt/RunTrustedTallyDecryption.kt
@@ -106,7 +106,7 @@ fun runDecryptTally(
             decryptedTally,
             mapOf(
                 Pair("CreatedBy", createdBy ?: "RunTrustedTallyDecryption"),
-                Pair("CreatedOn", getSystemDate().toString()),
+                Pair("CreatedOn", getSystemDate()),
                 Pair("CreatedFromDir", inputDir))
         )
     )

--- a/egklib/src/commonMain/kotlin/electionguard/encrypt/AddEncryptedBallot.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/encrypt/AddEncryptedBallot.kt
@@ -12,7 +12,6 @@ import electionguard.core.hashFunction
 import electionguard.input.BallotInputValidation
 import electionguard.input.ManifestInputValidation
 import electionguard.publish.*
-import io.ktor.utils.io.core.Closeable
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger("AddEncryptedBallot")

--- a/egklib/src/commonMain/kotlin/electionguard/encrypt/RunBatchEncryption.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/encrypt/RunBatchEncryption.kt
@@ -216,7 +216,7 @@ fun batchEncryption(
     publisher.writeElectionInitialized(
         electionInit.addMetadataToCopy(
             Pair("Used", createdBy ?: "RunBatchEncryption"),
-            Pair("UsedOn", getSystemDate().toString()),
+            Pair("UsedOn", getSystemDate()),
             Pair("CreatedFromDir", inputDir)
         )
     )

--- a/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/keyceremony/KeyCeremony.kt
@@ -156,7 +156,7 @@ data class KeyCeremonyResults(
 
         val metadataAll = mutableMapOf(
             Pair("CreatedBy", "keyCeremonyExchange"),
-            Pair("CreatedOn", getSystemDate().toString()),
+            Pair("CreatedOn", getSystemDate()),
         )
         metadataAll.putAll(metadata)
 

--- a/egklib/src/commonMain/kotlin/electionguard/publish/Publisher.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/publish/Publisher.kt
@@ -2,7 +2,6 @@ package electionguard.publish
 
 import electionguard.ballot.*
 import electionguard.keyceremony.KeyCeremonyTrustee
-import io.ktor.utils.io.core.Closeable
 
 /** Write the Election Record as protobuf or json files. */
 interface Publisher {
@@ -27,6 +26,11 @@ interface EncryptedBallotSinkIF : Closeable {
 
 interface DecryptedTallyOrBallotSinkIF : Closeable {
     fun writeDecryptedTallyOrBallot(tally: DecryptedTallyOrBallot)
+}
+
+// copied from io.ktor.utils.io.core.Closeable to break package dependency
+interface Closeable {
+    fun close()
 }
 
 fun makePublisher(

--- a/egklib/src/commonMain/kotlin/electionguard/publish/RunElectionRecordConvert.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/publish/RunElectionRecordConvert.kt
@@ -2,7 +2,6 @@ package electionguard.publish
 
 import electionguard.core.GroupContext
 import electionguard.core.productionGroup
-import io.ktor.utils.io.core.use
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.required
@@ -56,11 +55,14 @@ fun runElectionRecordConvert(group: GroupContext, inputDir: String, outputDir: S
     }
 
     var ecount = 0
-    publisher.encryptedBallotSink("fake").use { esink ->
+    val esink = publisher.encryptedBallotSink("fake")
+    try {
         consumer.iterateAllEncryptedBallots { true }.forEach() {
             esink.writeEncryptedBallot(it)
             ecount++
         }
+    } finally {
+        esink.close()
     }
     println(" $ecount encryptedBallots written")
 
@@ -77,11 +79,14 @@ fun runElectionRecordConvert(group: GroupContext, inputDir: String, outputDir: S
     }
 
     var dcount = 0
-    publisher.decryptedTallyOrBallotSink().use { dsink ->
+    val dsink = publisher.decryptedTallyOrBallotSink()
+    try {
         consumer.iterateDecryptedBallots().forEach() {
             dsink.writeDecryptedTallyOrBallot(it)
             dcount++
         }
+    } finally {
+        dsink.close()
     }
     println(" $dcount decryptedBallots written")
 }

--- a/egklib/src/commonMain/kotlin/electionguard/tally/RunAccumulateTally.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/tally/RunAccumulateTally.kt
@@ -68,7 +68,7 @@ fun runAccumulateBallots(group: GroupContext, inputDir: String, outputDir: Strin
         TallyResult( electionInit, tally, listOf(name),
             mapOf(
                 Pair("CreatedBy", createdBy),
-                Pair("CreatedOn", getSystemDate().toString()),
+                Pair("CreatedOn", getSystemDate()),
                 Pair("CreatedFromDir", inputDir))
             )
     )

--- a/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyEncryptedBallots.kt
+++ b/egklib/src/commonMain/kotlin/electionguard/verifier/VerifyEncryptedBallots.kt
@@ -37,7 +37,7 @@ class VerifyEncryptedBallots(
 ) {
     val aggregator = SelectionAggregator() // for Verification 8 (Correctness of ballot aggregation)
 
-    fun verifyBallots(ballots: Iterable<EncryptedBallot>, stats: Stats, showTime: Boolean = false): Result<Boolean, String> {
+    fun verifyBallots(ballots: Iterable<EncryptedBallot>, stats: Stats = Stats(), showTime: Boolean = false): Result<Boolean, String> {
         val starting = getSystemTimeInMillis()
 
         runBlocking {

--- a/egklib/src/commonTest/kotlin/electionguard/ballot/ElectionConfigTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/ballot/ElectionConfigTest.kt
@@ -2,7 +2,6 @@ package electionguard.ballot
 
 import electionguard.core.Base16.toHex
 import electionguard.core.productionGroup
-import io.ktor.utils.io.core.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -20,7 +19,7 @@ class ElectionConfigTest {
         // The array has length 32 and contains the UTF-8 encoding of the string "v2.0" followed by 00-
         // bytes, i.e. HV = 76322E30 ∥ b(0, 28).
 
-        val ver = "v2.0.0".toByteArray()
+        val ver = "v2.0.0".encodeToByteArray()
         println("ver = ${ver.toHex()}")
         assertEquals(6, ver.size)
         val HV = ByteArray(32) { if (it < ver.size) ver[it] else 0 }

--- a/egklib/src/jvmMain/kotlin/electionguard/cli/ExampleEncryption.kt
+++ b/egklib/src/jvmMain/kotlin/electionguard/cli/ExampleEncryption.kt
@@ -1,0 +1,77 @@
+package electionguard.cli
+
+import com.github.michaelbull.result.unwrap
+import electionguard.ballot.EncryptedBallot
+import electionguard.core.*
+import electionguard.encrypt.AddEncryptedBallot
+import electionguard.input.RandomBallotProvider
+import electionguard.publish.makeConsumer
+import electionguard.publish.makePublisher
+import electionguard.publish.readElectionRecord
+import electionguard.verifier.VerifyEncryptedBallots
+
+fun main(args: Array<String>) {
+    val inputDir = "src/commonTest/data/workflow/allAvailableJson"
+    val outputDir = "testOut/encrypt/ExampleEncryption"
+    val device = "device0"
+    val chained = false
+
+    val group = productionGroup()
+    val electionRecord = readElectionRecord(group, inputDir)
+    val electionInit = electionRecord.electionInit()!!
+    val publisher = makePublisher(outputDir, true, true)
+    publisher.writeElectionInitialized(electionInit)
+
+    val encryptor = AddEncryptedBallot(
+        group,
+        electionRecord.manifest(),
+        electionInit,
+        device,
+        electionRecord.config().configBaux0,
+        chained,
+        outputDir,
+        "${outputDir}/invalidDir",
+        true, // isJson
+        false,
+    )
+
+    // encrypt 7 randomly generated ballots
+    val ballotProvider = RandomBallotProvider(electionRecord.manifest())
+    repeat(7) {
+        val ballot = ballotProvider.makeBallot()
+        val result = encryptor.encrypt(ballot)
+        encryptor.submit(result.unwrap().ballotId, EncryptedBallot.BallotState.CAST)
+    }
+
+    // write out the results to outputDir
+    encryptor.close()
+
+    // verify
+    verifyOutput(group, outputDir, chained)
+}
+
+fun verifyOutput(group: GroupContext, outputDir: String, chained: Boolean = false) {
+    val consumer = makeConsumer(outputDir, group, false)
+    var count = 0
+    consumer.iterateAllEncryptedBallots { true }.forEach {
+        count++
+    }
+    println("$count EncryptedBallots")
+
+    val record = readElectionRecord(consumer)
+    val verifier = VerifyEncryptedBallots(
+        group, record.manifest(),
+        ElGamalPublicKey(record.jointPublicKey()!!),
+        record.extendedBaseHash()!!,
+        record.config(), 1
+    )
+
+    // Note we are verifying all ballots, not just CAST
+    val verifierResult = verifier.verifyBallots(record.encryptedAllBallots { true })
+    println("verifyEncryptedBallots $verifierResult")
+
+    if (chained) {
+        val chainResult = verifier.verifyConfirmationChain(record)
+        println(" verifyChain $chainResult")
+    }
+}


### PR DESCRIPTION
Add electionguard.cli.ExampleEncryptionKt (jvm only) see Issues #343, #344. 
Remove libs.ktor.utils from egklib.
getSystemDate() returns String.
native code: use Int.convert() wherever we are getting a type failure.