### PR TITLE
Upgrade for CLI programs (take 2)

### DIFF
--- a/egklib/src/commonTest/kotlin/electionguard/core/HashTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/HashTest.kt
@@ -4,7 +4,6 @@ import electionguard.core.Base16.fromSafeHex
 import electionguard.core.Base16.toHex
 import io.kotest.property.checkAll
 import io.kotest.property.forAll
-import io.ktor.utils.io.core.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -84,8 +83,8 @@ class HashTest {
             val s2q = "000C49A1E8053FBA95F6B7CD3F3B30B101CDD595C435A46AECF2872F47F1C601206".fromSafeHex()
                 .toUInt256().toElementModQ(group).base16()
             assertEquals(s1q, s2q)
-            assertEquals(s1q.toByteArray().size, s2q.toByteArray().size)
-            assertEquals(hashFunction(s1q.toByteArray(), s1q), hashFunction(s2q.toByteArray(), s2q))
+            assertEquals(s1q.encodeToByteArray().size, s2q.encodeToByteArray().size)
+            assertEquals(hashFunction(s1q.encodeToByteArray(), s1q), hashFunction(s2q.encodeToByteArray(), s2q))
             println("  len = ${s1q.length} hex = ${s1q}")
             assertEquals(64, s1q.length)
         }
@@ -104,8 +103,8 @@ class HashTest {
     @Test
     fun testIterable() {
         runTest {
-            val h1 = hashFunction("hay1".toByteArray(), listOf("hey2", "hey3"))
-            val h2 = hashFunction("hay1".toByteArray(), "hey2", "hey3")
+            val h1 = hashFunction("hay1".encodeToByteArray(), listOf("hey2", "hey3"))
+            val h2 = hashFunction("hay1".encodeToByteArray(), "hey2", "hey3")
             println(" h1 = ${h1}")
             println(" h2 = ${h2}")
             assertEquals(h1, h2)

--- a/egklib/src/commonTest/kotlin/electionguard/core/HmacSha256Test.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/HmacSha256Test.kt
@@ -2,7 +2,6 @@ package electionguard.core
 
 import electionguard.ballot.parameterBaseHash
 import electionguard.ballot.protocolVersion
-import io.ktor.utils.io.core.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -32,7 +31,7 @@ class HmacSha256Test {
         // The symbol HV denotes the version byte array that encodes the used version of this specification.
         // The array has length 32 and contains the UTF-8 encoding of the string "v2.0" followed by 00-
         // bytes, i.e. HV = 76322E30 ∥ b(0, 28).
-        val version = protocolVersion.toByteArray()
+        val version = protocolVersion.encodeToByteArray()
         val HV = ByteArray(32) { if (it < version.size ) version[it] else 0 }
 
         val callConcat = hashFunctionConcat(
@@ -68,7 +67,7 @@ class HmacSha256Test {
         val primes = productionGroup().constants
 
         // HP = H(HV ; 00, p, q, g)  ; eq 4
-        val version = protocolVersion.toByteArray()
+        val version = protocolVersion.encodeToByteArray()
         val HV = ByteArray(32) { if (it < version.size ) version[it] else 0 }
 
         val callConcat = hashFunctionConcat(
@@ -95,7 +94,7 @@ class HmacSha256Test {
 
     @Test
     fun domainSeperator() {
-        val sep = "43".toByteArray()
+        val sep = "43".encodeToByteArray()
         println("sep 43 = ${sep.contentToString()}")
 
         val sep2 = "43".toLong(radix = 16)

--- a/egklib/src/commonTest/kotlin/electionguard/core/TestUtils.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/core/TestUtils.kt
@@ -1,6 +1,5 @@
 package electionguard.core
 
-import io.ktor.utils.io.core.*
 import kotlin.random.Random
 import kotlin.random.nextUInt
 import kotlin.test.Test
@@ -100,7 +99,7 @@ fun generateCiphertext(context: GroupContext): ElGamalCiphertext {
 }
 
 fun generateHashedCiphertext(context: GroupContext): HashedElGamalCiphertext {
-    return HashedElGamalCiphertext(generateElementModP(context), "what".toByteArray(), generateUInt256(context), 42)
+    return HashedElGamalCiphertext(generateElementModP(context), "what".encodeToByteArray(), generateUInt256(context), 42)
 }
 
 fun generateElementModQ(context: GroupContext): ElementModQ {

--- a/egklib/src/commonTest/kotlin/electionguard/json2/EncryptedBallotTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/json2/EncryptedBallotTest.kt
@@ -2,7 +2,6 @@ package electionguard.json2
 
 import electionguard.ballot.EncryptedBallot
 import electionguard.core.*
-import io.ktor.utils.io.core.*
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,7 +18,7 @@ class EncryptedBallotTest {
         val roundtrip = json.import(context)
         assertNotNull(roundtrip)
         assertEquals(ballot, roundtrip)
-        assertTrue("baux".toByteArray().contentEquals(roundtrip.codeBaux))
+        assertTrue("baux".encodeToByteArray().contentEquals(roundtrip.codeBaux))
     }
 
     @Test
@@ -39,7 +38,7 @@ class EncryptedBallotTest {
             "ballotIdStyle",
             "device",
             42,
-            "baux".toByteArray(),
+            "baux".encodeToByteArray(),
             generateUInt256(context),
             contests,
             if (Random.nextBoolean())

--- a/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/keyceremony/KeyCeremonyTest.kt
@@ -5,7 +5,6 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.getError
 import electionguard.ballot.*
 import electionguard.core.*
-import io.ktor.utils.io.core.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -41,7 +40,7 @@ class KeyCeremonyTest {
             2,
             ByteArray(0),
             false,
-            "device".toByteArray(),
+            "device".encodeToByteArray(),
         )
         val init: ElectionInitialized = kc.makeElectionInitialized(config)
 

--- a/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/preencrypt/PreEncryptorTest.kt
@@ -18,7 +18,6 @@ import electionguard.verifier.VerifyEncryptedBallots
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
-import io.ktor.utils.io.core.*
 import kotlin.math.min
 import kotlin.random.Random
 import kotlin.test.Test
@@ -394,8 +393,8 @@ fun makeFakeConfig() : ElectionConfig {
         productionGroup().constants,
         3,
         3,
-        "manifest".toByteArray(),
+        "manifest".encodeToByteArray(),
         false,
-        "device".toByteArray(),
+        "device".encodeToByteArray(),
     )
 }

--- a/egklib/src/commonTest/kotlin/electionguard/protoconvert/ElectionConfigConvertTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/protoconvert/ElectionConfigConvertTest.kt
@@ -6,10 +6,8 @@ import electionguard.core.fileReadBytes
 import electionguard.core.productionGroup
 import electionguard.input.buildTestManifest
 import electionguard.publish.*
-import io.ktor.utils.io.core.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /** Can use this to generate a new ElectionConfig as needed. */
@@ -47,7 +45,7 @@ class ElectionConfigConvertTest {
             7,
             manifestBytes,
             true,
-            "device".toByteArray(),
+            "device".encodeToByteArray(),
             mapOf(
                 Pair("Created by", "roundtripWithChain"),
                 Pair("Created for", "testing"),
@@ -115,7 +113,7 @@ fun generateElectionConfig(publisher: Publisher, nguardians: Int, quorum: Int): 
         quorum,
         manifestBytes,
         false,
-        "device".toByteArray(),
+        "device".encodeToByteArray(),
         mapOf(Pair("Created by", "generateElectionConfig")),
         )
     return Pair(fakeManifest, config)

--- a/egklib/src/commonTest/kotlin/electionguard/workflow/ContestDataTest.kt
+++ b/egklib/src/commonTest/kotlin/electionguard/workflow/ContestDataTest.kt
@@ -7,10 +7,8 @@ import electionguard.core.*
 import electionguard.encrypt.Encryptor
 import electionguard.encrypt.cast
 import electionguard.input.BallotInputBuilder
-import electionguard.publish.Publisher
 import electionguard.publish.makePublisher
 import electionguard.publish.readElectionRecord
-import io.ktor.utils.io.core.*
 import pbandk.decodeFromByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -62,7 +60,8 @@ class ContestDataTest {
             .done()
             .build()
 
-        val encryptor = Encryptor(context, electionRecord.manifest(), keypair.publicKey, electionInit.extendedBaseHash, "device")
+        val encryptor =
+            Encryptor(context, electionRecord.manifest(), keypair.publicKey, electionInit.extendedBaseHash, "device")
         val eballot = encryptor.encrypt(ballot, ByteArray(0))
 
         eballot.contests.forEachIndexed { idx, it ->
@@ -90,35 +89,42 @@ class ContestDataTest {
                     assertEquals(ContestDataStatus.normal, contestDataRoundtrip.status)
                     assertEquals(emptyList(), contestDataRoundtrip.writeIns)
                 }
+
                 1 -> {
                     assertEquals(ContestDataStatus.normal, contestDataRoundtrip.status)
                     assertEquals(listOf("Sekula-Gibbs"), contestDataRoundtrip.writeIns)
                 }
+
                 2 -> {
                     assertEquals(ContestDataStatus.over_vote, contestDataRoundtrip.status)
                     assertEquals(listOf("SekulaGibbs"), contestDataRoundtrip.writeIns)
                     assertEquals(listOf(8), contestDataRoundtrip.overvotes)
                 }
+
                 3 -> {
                     assertEquals(ContestDataStatus.over_vote, contestDataRoundtrip.status)
                     assertEquals(listOf("SekulaGibbs", "Sekula-Gibbs"), contestDataRoundtrip.writeIns)
                     assertEquals(listOf(12, 13), contestDataRoundtrip.overvotes)
                 }
+
                 4 -> {
                     assertEquals(ContestDataStatus.normal, contestDataRoundtrip.status)
                     assertEquals(listOf("012345678901234567890123456789*"), contestDataRoundtrip.writeIns)
                     assertEquals(emptyList(), contestDataRoundtrip.overvotes)
                 }
+
                 5 -> {
                     assertEquals(ContestDataStatus.over_vote, contestDataRoundtrip.status)
                     assertEquals(listOf("012345678901234567890123456789*"), contestDataRoundtrip.writeIns)
                     assertEquals(listOf(20), contestDataRoundtrip.overvotes)
                 }
+
                 6 -> {
                     assertEquals(ContestDataStatus.over_vote, contestDataRoundtrip.status)
                     assertEquals(emptyList(), contestDataRoundtrip.writeIns)
                     assertEquals(listOf(24, 25, 26, 27), contestDataRoundtrip.overvotes)
                 }
+
                 else -> {
                     assertEquals(ContestDataStatus.null_vote, contestDataRoundtrip.status)
                     assertEquals(emptyList(), contestDataRoundtrip.writeIns)
@@ -128,14 +134,14 @@ class ContestDataTest {
 
         val publisherProto = makePublisher(output, true, false)
         publisherProto.writeElectionInitialized(electionInit)
-        publisherProto.encryptedBallotSink("testWriteEncryptions").use { sink ->
-            sink.writeEncryptedBallot(eballot.cast())
-        }
+        val sink = publisherProto.encryptedBallotSink("testWriteEncryptions")
+        sink.writeEncryptedBallot(eballot.cast())
+        sink.close()
 
         val publisherJson = makePublisher(output + "Json", true, true)
         publisherJson.writeElectionInitialized(electionInit)
-        publisherJson.encryptedBallotSink("testWriteEncryptions").use { sink ->
-            sink.writeEncryptedBallot(eballot.cast())
-        }
+        val sink2 = publisherJson.encryptedBallotSink("testWriteEncryptions")
+        sink2.writeEncryptedBallot(eballot.cast())
+        sink2.close()
     }
 }

--- a/egklib/src/jvmTest/kotlin/electionguard/core/TestPrimes.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/core/TestPrimes.kt
@@ -2,7 +2,6 @@ package electionguard.core
 
 import electionguard.ballot.parameterBaseHash
 import electionguard.core.Base16.fromHex
-import io.ktor.utils.io.core.*
 import org.junit.jupiter.api.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals

--- a/egklib/src/jvmTest/kotlin/electionguard/testvectors/PreEncryptionRecordedTestVector.kt
+++ b/egklib/src/jvmTest/kotlin/electionguard/testvectors/PreEncryptionRecordedTestVector.kt
@@ -12,7 +12,6 @@ import electionguard.preencrypt.MarkedPreEncryptedBallot
 import electionguard.preencrypt.MarkedPreEncryptedContest
 import electionguard.protoconvert.import
 import electionguard.protoconvert.publishProto
-import io.ktor.utils.io.core.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/egklib/src/nativeMain/kotlin/electionguard/publish/PublisherJson.kt
+++ b/egklib/src/nativeMain/kotlin/electionguard/publish/PublisherJson.kt
@@ -4,7 +4,6 @@ import electionguard.ballot.*
 import electionguard.core.pathExists
 import electionguard.json2.*
 import electionguard.keyceremony.KeyCeremonyTrustee
-import io.ktor.utils.io.core.use
 import kotlinx.cinterop.CPointer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json


### PR DESCRIPTION
Add electionguard.cli.ExampleEncryptionKt (jvm only)  see Issues #343, #344. 
Remove libs.ktor.utils from egklib.
getSystemDate() returns String.
native code: use Int.convert() wherever we are getting a type failure.